### PR TITLE
fix: Center all landing page sections for desktop displays

### DIFF
--- a/src/components/landing/contact-section.tsx
+++ b/src/components/landing/contact-section.tsx
@@ -50,7 +50,7 @@ export function ContactSection() {
       className="py-20 md:py-28 bg-gradient-hero text-white"
       id="contact"
     >
-      <div className="container px-4 md:px-6 max-w-6xl">
+      <div className="container px-4 md:px-6 max-w-6xl mx-auto">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}

--- a/src/components/landing/credentials-bar.tsx
+++ b/src/components/landing/credentials-bar.tsx
@@ -16,7 +16,7 @@ const credentials = [
 export function CredentialsBar() {
   return (
     <section className="py-10 md:py-14 bg-white border-y border-border/50">
-      <div className="container px-4 md:px-6">
+      <div className="container px-4 md:px-6 max-w-7xl mx-auto">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}

--- a/src/components/landing/hero-section.tsx
+++ b/src/components/landing/hero-section.tsx
@@ -50,7 +50,7 @@ export function HeroSection() {
       <div className="absolute top-1/4 -left-32 w-96 h-96 bg-accent/20 rounded-full blur-[128px] animate-pulse-subtle" />
       <div className="absolute bottom-1/4 -right-32 w-96 h-96 bg-primary/30 rounded-full blur-[128px] animate-pulse-subtle" style={{ animationDelay: "1s" }} />
 
-      <div className="container relative z-10 px-4 md:px-6 py-16 md:py-24">
+      <div className="container relative z-10 px-4 md:px-6 py-16 md:py-24 max-w-7xl mx-auto">
         <motion.div
           initial="initial"
           animate="animate"

--- a/src/components/landing/photo-gallery.tsx
+++ b/src/components/landing/photo-gallery.tsx
@@ -82,7 +82,7 @@ const galleryImages = [
 export function PhotoGallery() {
   return (
     <section className="py-20 md:py-28 bg-secondary/30 overflow-hidden">
-      <div className="container px-4 md:px-6">
+      <div className="container px-4 md:px-6 max-w-7xl mx-auto">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}

--- a/src/components/landing/results-section.tsx
+++ b/src/components/landing/results-section.tsx
@@ -30,7 +30,7 @@ const results = [
 export function ResultsSection() {
   return (
     <section className="py-20 md:py-28 bg-white">
-      <div className="container px-4 md:px-6">
+      <div className="container px-4 md:px-6 max-w-6xl mx-auto">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}

--- a/src/components/landing/services-section.tsx
+++ b/src/components/landing/services-section.tsx
@@ -40,7 +40,7 @@ const services = [
 export function ServicesSection() {
   return (
     <section className="py-20 md:py-28 bg-secondary/30" id="services">
-      <div className="container px-4 md:px-6">
+      <div className="container px-4 md:px-6 max-w-7xl mx-auto">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}

--- a/src/components/landing/services-tabs.tsx
+++ b/src/components/landing/services-tabs.tsx
@@ -82,7 +82,7 @@ const tabs = [
 export function ServicesTabsSection() {
   return (
     <section className="py-20 md:py-28 bg-gradient-hero text-white" id="workshops">
-      <div className="container px-4 md:px-6">
+      <div className="container px-4 md:px-6 max-w-7xl mx-auto">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}

--- a/src/components/landing/signature-work.tsx
+++ b/src/components/landing/signature-work.tsx
@@ -69,7 +69,7 @@ const projects = [
 export function SignatureWorkSection() {
   return (
     <section className="py-20 md:py-28 bg-secondary/30">
-      <div className="container px-4 md:px-6">
+      <div className="container px-4 md:px-6 max-w-7xl mx-auto">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}

--- a/src/components/landing/testimonials-section.tsx
+++ b/src/components/landing/testimonials-section.tsx
@@ -78,7 +78,7 @@ const sizeStyles = {
 export function TestimonialsSection() {
   return (
     <section className="py-20 md:py-28 bg-white overflow-hidden">
-      <div className="container px-4 md:px-6">
+      <div className="container px-4 md:px-6 max-w-7xl mx-auto">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}

--- a/src/components/landing/video-section.tsx
+++ b/src/components/landing/video-section.tsx
@@ -11,7 +11,7 @@ export function VideoSection() {
 
   return (
     <section className="py-16 md:py-24 bg-white">
-      <div className="container px-4 md:px-6">
+      <div className="container px-4 md:px-6 max-w-6xl mx-auto">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}

--- a/src/components/landing/workshop-topics.tsx
+++ b/src/components/landing/workshop-topics.tsx
@@ -46,7 +46,7 @@ export function WorkshopTopicsSection() {
 
   return (
     <section className="py-20 md:py-28 bg-secondary/30">
-      <div className="container px-4 md:px-6 max-w-5xl">
+      <div className="container px-4 md:px-6 max-w-5xl mx-auto">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}


### PR DESCRIPTION
Add mx-auto and max-width constraints to all section containers to ensure consistent horizontal centering on wide screens.

Sections updated:
- HeroSection, CredentialsBar, ServicesSection (max-w-7xl)
- VideoSection, ResultsSection, ContactSection (max-w-6xl)
- SignatureWorkSection, PhotoGallery, TestimonialsSection (max-w-7xl)
- ServicesTabsSection, WorkshopTopicsSection (max-w-7xl/5xl)