### PR TITLE
feat: Add Find a Group page for singer matching

### DIFF
--- a/src/app/find-group/page.tsx
+++ b/src/app/find-group/page.tsx
@@ -1,0 +1,337 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Users,
+  MapPin,
+  Music,
+  ArrowRight,
+  CheckCircle2,
+  Heart,
+  Sparkles,
+  Globe,
+  MessageCircle,
+} from "lucide-react";
+import { FindGroupForm } from "@/components/find-group/find-group-form";
+
+export const metadata = {
+  title: "Find a Singing Group | Deke Sharon",
+  description:
+    "Looking to join a singing group? Submit your preferences and we'll help match you with the perfect a cappella, choir, or vocal ensemble near you.",
+};
+
+const benefits = [
+  {
+    icon: Users,
+    title: "Community Connection",
+    description:
+      "Join a welcoming community of singers who share your passion for harmony and performance.",
+  },
+  {
+    icon: Music,
+    title: "Musical Growth",
+    description:
+      "Develop your vocal skills, learn new techniques, and expand your musical horizons with experienced groups.",
+  },
+  {
+    icon: Heart,
+    title: "Lifelong Friendships",
+    description:
+      "Singing together creates bonds that last. Find your tribe and make meaningful connections.",
+  },
+  {
+    icon: Sparkles,
+    title: "Performance Opportunities",
+    description:
+      "From casual gigs to competitions, discover opportunities to share your voice with the world.",
+  },
+];
+
+const groupTypes = [
+  {
+    title: "A Cappella Groups",
+    description: "Contemporary vocal groups performing without instruments",
+    genres: ["Pop", "Jazz", "Rock", "R&B"],
+  },
+  {
+    title: "Choirs & Choruses",
+    description: "Traditional and modern choral ensembles of all sizes",
+    genres: ["Classical", "Gospel", "Folk", "World"],
+  },
+  {
+    title: "Barbershop Quartets",
+    description: "Close harmony singing in the classic barbershop style",
+    genres: ["Barbershop", "Doo-wop", "Standards"],
+  },
+  {
+    title: "Community Groups",
+    description: "Casual singing groups for all skill levels",
+    genres: ["Mixed", "All genres welcome"],
+  },
+];
+
+const stats = [
+  { number: "1,000+", label: "Groups Worldwide" },
+  { number: "50+", label: "Countries" },
+  { number: "95%", label: "Match Rate" },
+];
+
+export default function FindGroupPage() {
+  return (
+    <>
+      {/* Hero */}
+      <section className="bg-gradient-to-br from-primary/5 via-background to-accent/5 py-16 md:py-24">
+        <div className="container px-4 md:px-6">
+          <div className="grid gap-12 lg:grid-cols-2 lg:gap-16 items-center">
+            <div>
+              <Badge variant="secondary" className="mb-4">
+                <Users className="h-3 w-3 mr-1" />
+                Find Your Voice
+              </Badge>
+              <h1 className="font-heading text-4xl md:text-5xl font-bold mb-6">
+                Find Your Perfect Singing Group
+              </h1>
+              <p className="text-lg text-muted-foreground mb-8">
+                Whether you&apos;re a seasoned performer or just starting your
+                vocal journey, we&apos;ll help you find a group that matches
+                your style, schedule, and goals.
+              </p>
+              <div className="flex flex-wrap gap-4 mb-8">
+                {stats.map((stat) => (
+                  <div key={stat.label} className="text-center px-4">
+                    <p className="text-3xl font-bold text-primary">
+                      {stat.number}
+                    </p>
+                    <p className="text-sm text-muted-foreground">{stat.label}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Request Form Card */}
+            <Card className="border-2 shadow-lg">
+              <CardHeader>
+                <CardTitle className="font-heading text-xl flex items-center gap-2">
+                  <MessageCircle className="h-5 w-5 text-primary" />
+                  Tell Us About Yourself
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <FindGroupForm />
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      {/* Benefits */}
+      <section className="py-20 md:py-28">
+        <div className="container px-4 md:px-6">
+          <div className="text-center mb-12">
+            <Badge variant="outline" className="mb-4">
+              Why Join a Group?
+            </Badge>
+            <h2 className="font-heading text-3xl md:text-4xl font-bold mb-4">
+              More Than Just Singing
+            </h2>
+            <p className="text-muted-foreground max-w-2xl mx-auto">
+              Joining a singing group opens doors to experiences that go far
+              beyond making music together.
+            </p>
+          </div>
+
+          <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-4">
+            {benefits.map((benefit) => (
+              <Card key={benefit.title} className="text-center">
+                <CardContent className="pt-6">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10 text-primary mx-auto mb-4">
+                    <benefit.icon className="h-6 w-6" />
+                  </div>
+                  <h3 className="font-heading font-semibold text-lg mb-2">
+                    {benefit.title}
+                  </h3>
+                  <p className="text-sm text-muted-foreground">
+                    {benefit.description}
+                  </p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Group Types */}
+      <section className="py-20 md:py-28 bg-muted/30">
+        <div className="container px-4 md:px-6">
+          <div className="text-center mb-12">
+            <Badge variant="outline" className="mb-4">
+              <Globe className="h-3 w-3 mr-1" />
+              Group Types
+            </Badge>
+            <h2 className="font-heading text-3xl md:text-4xl font-bold mb-4">
+              Every Style of Singing
+            </h2>
+            <p className="text-muted-foreground max-w-2xl mx-auto">
+              From barbershop quartets to contemporary a cappella, we connect
+              singers with groups across all genres and styles.
+            </p>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+            {groupTypes.map((type) => (
+              <Card key={type.title}>
+                <CardContent className="pt-6">
+                  <h3 className="font-heading font-semibold text-lg mb-2">
+                    {type.title}
+                  </h3>
+                  <p className="text-sm text-muted-foreground mb-4">
+                    {type.description}
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    {type.genres.map((genre) => (
+                      <Badge key={genre} variant="secondary" className="text-xs">
+                        {genre}
+                      </Badge>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* How It Works */}
+      <section className="py-20 md:py-28">
+        <div className="container px-4 md:px-6">
+          <div className="text-center mb-12">
+            <Badge variant="outline" className="mb-4">
+              How It Works
+            </Badge>
+            <h2 className="font-heading text-3xl md:text-4xl font-bold mb-4">
+              Simple Steps to Your New Group
+            </h2>
+          </div>
+
+          <div className="grid gap-8 md:grid-cols-3 max-w-4xl mx-auto">
+            <div className="text-center">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary text-primary-foreground font-bold text-xl mx-auto mb-4">
+                1
+              </div>
+              <h3 className="font-heading font-semibold text-lg mb-2">
+                Share Your Preferences
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                Tell us about your experience level, musical interests, location,
+                and availability.
+              </p>
+            </div>
+            <div className="text-center">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary text-primary-foreground font-bold text-xl mx-auto mb-4">
+                2
+              </div>
+              <h3 className="font-heading font-semibold text-lg mb-2">
+                We Find Matches
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                Our network and expertise help identify groups that fit your
+                criteria and goals.
+              </p>
+            </div>
+            <div className="text-center">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary text-primary-foreground font-bold text-xl mx-auto mb-4">
+                3
+              </div>
+              <h3 className="font-heading font-semibold text-lg mb-2">
+                Connect & Audition
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                We introduce you to compatible groups and help facilitate your
+                audition process.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ Section */}
+      <section className="py-20 md:py-28 bg-muted/30">
+        <div className="container px-4 md:px-6">
+          <div className="text-center mb-12">
+            <Badge variant="outline" className="mb-4">
+              FAQ
+            </Badge>
+            <h2 className="font-heading text-3xl md:text-4xl font-bold mb-4">
+              Common Questions
+            </h2>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2 max-w-4xl mx-auto">
+            <Card>
+              <CardContent className="pt-6">
+                <h3 className="font-semibold mb-2">Do I need experience?</h3>
+                <p className="text-sm text-muted-foreground">
+                  Not at all! Groups range from beginner-friendly community
+                  choirs to advanced competitive ensembles. We match you based on
+                  your current skill level.
+                </p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="pt-6">
+                <h3 className="font-semibold mb-2">Is there a fee?</h3>
+                <p className="text-sm text-muted-foreground">
+                  Our matching service is free. Individual groups may have their
+                  own membership dues or audition processes.
+                </p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="pt-6">
+                <h3 className="font-semibold mb-2">How long does matching take?</h3>
+                <p className="text-sm text-muted-foreground">
+                  Typically 1-2 weeks. We review your preferences and reach out
+                  with potential matches as we find them.
+                </p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="pt-6">
+                <h3 className="font-semibold mb-2">What if I&apos;m in a small town?</h3>
+                <p className="text-sm text-muted-foreground">
+                  We have connections worldwide and can also suggest starting your
+                  own group or joining virtual ensembles.
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-20 md:py-28 bg-primary text-primary-foreground">
+        <div className="container px-4 md:px-6 text-center">
+          <h2 className="font-heading text-3xl md:text-4xl font-bold mb-4">
+            Ready to Start Singing?
+          </h2>
+          <p className="text-primary-foreground/80 max-w-2xl mx-auto mb-8">
+            Join thousands of singers who have found their perfect musical home.
+            Your next harmony is waiting.
+          </p>
+          <Button
+            size="lg"
+            variant="secondary"
+            className="bg-white text-primary hover:bg-white/90"
+            asChild
+          >
+            <Link href="#top">
+              Submit Your Request
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Link>
+          </Button>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/components/find-group/find-group-form.tsx
+++ b/src/components/find-group/find-group-form.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { ArrowRight, Loader2, CheckCircle2 } from "lucide-react";
+
+const experienceLevels = [
+  { value: "beginner", label: "Beginner - New to singing in groups" },
+  { value: "intermediate", label: "Intermediate - Some group experience" },
+  { value: "advanced", label: "Advanced - Experienced performer" },
+  { value: "professional", label: "Professional - Career vocalist" },
+];
+
+const genres = [
+  "Pop",
+  "Jazz",
+  "Classical",
+  "Gospel",
+  "R&B",
+  "Rock",
+  "Barbershop",
+  "Folk",
+  "World Music",
+  "Musical Theatre",
+];
+
+const commitmentLevels = [
+  { value: "casual", label: "Casual - Once a month or less" },
+  { value: "regular", label: "Regular - Weekly rehearsals" },
+  { value: "intensive", label: "Intensive - Multiple times per week" },
+  { value: "flexible", label: "Flexible - Open to any commitment level" },
+];
+
+export function FindGroupForm() {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [selectedGenres, setSelectedGenres] = useState<string[]>([]);
+  const [formData, setFormData] = useState({
+    name: "",
+    email: "",
+    location: "",
+    age: "",
+    experience: "",
+    commitment: "",
+    performanceInterest: false,
+    message: "",
+  });
+
+  const handleGenreToggle = (genre: string) => {
+    setSelectedGenres((prev) =>
+      prev.includes(genre)
+        ? prev.filter((g) => g !== genre)
+        : [...prev, genre]
+    );
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+
+    // Simulate API call
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+
+    // In production, this would POST to /api/group-requests
+    console.log("Form submitted:", { ...formData, genres: selectedGenres });
+
+    setIsSubmitting(false);
+    setIsSubmitted(true);
+  };
+
+  if (isSubmitted) {
+    return (
+      <div className="text-center py-8">
+        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-100 text-green-600 mx-auto mb-4">
+          <CheckCircle2 className="h-8 w-8" />
+        </div>
+        <h3 className="font-heading text-xl font-semibold mb-2">
+          Request Submitted!
+        </h3>
+        <p className="text-muted-foreground mb-4">
+          Thank you for reaching out. We&apos;ll review your preferences and get
+          back to you within 1-2 weeks with potential matches.
+        </p>
+        <Button
+          variant="outline"
+          onClick={() => {
+            setIsSubmitted(false);
+            setFormData({
+              name: "",
+              email: "",
+              location: "",
+              age: "",
+              experience: "",
+              commitment: "",
+              performanceInterest: false,
+              message: "",
+            });
+            setSelectedGenres([]);
+          }}
+        >
+          Submit Another Request
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="name">Full Name *</Label>
+          <Input
+            id="name"
+            placeholder="Your name"
+            required
+            value={formData.name}
+            onChange={(e) =>
+              setFormData((prev) => ({ ...prev, name: e.target.value }))
+            }
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="email">Email *</Label>
+          <Input
+            id="email"
+            type="email"
+            placeholder="you@example.com"
+            required
+            value={formData.email}
+            onChange={(e) =>
+              setFormData((prev) => ({ ...prev, email: e.target.value }))
+            }
+          />
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="location">Location *</Label>
+          <Input
+            id="location"
+            placeholder="City, State/Country"
+            required
+            value={formData.location}
+            onChange={(e) =>
+              setFormData((prev) => ({ ...prev, location: e.target.value }))
+            }
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="age">Age</Label>
+          <Input
+            id="age"
+            type="number"
+            placeholder="Optional"
+            min="10"
+            max="100"
+            value={formData.age}
+            onChange={(e) =>
+              setFormData((prev) => ({ ...prev, age: e.target.value }))
+            }
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="experience">Experience Level *</Label>
+        <Select
+          required
+          value={formData.experience}
+          onValueChange={(value) =>
+            setFormData((prev) => ({ ...prev, experience: value }))
+          }
+        >
+          <SelectTrigger id="experience">
+            <SelectValue placeholder="Select your experience level" />
+          </SelectTrigger>
+          <SelectContent>
+            {experienceLevels.map((level) => (
+              <SelectItem key={level.value} value={level.value}>
+                {level.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="commitment">Time Commitment *</Label>
+        <Select
+          required
+          value={formData.commitment}
+          onValueChange={(value) =>
+            setFormData((prev) => ({ ...prev, commitment: value }))
+          }
+        >
+          <SelectTrigger id="commitment">
+            <SelectValue placeholder="How often can you rehearse?" />
+          </SelectTrigger>
+          <SelectContent>
+            {commitmentLevels.map((level) => (
+              <SelectItem key={level.value} value={level.value}>
+                {level.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label>Preferred Genres (select all that apply)</Label>
+        <div className="flex flex-wrap gap-2 pt-1">
+          {genres.map((genre) => (
+            <button
+              key={genre}
+              type="button"
+              onClick={() => handleGenreToggle(genre)}
+              className={`px-3 py-1.5 text-sm rounded-full border transition-colors ${
+                selectedGenres.includes(genre)
+                  ? "bg-primary text-primary-foreground border-primary"
+                  : "bg-background hover:bg-muted border-input"
+              }`}
+            >
+              {genre}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id="performance"
+          checked={formData.performanceInterest}
+          onCheckedChange={(checked) =>
+            setFormData((prev) => ({
+              ...prev,
+              performanceInterest: checked === true,
+            }))
+          }
+        />
+        <Label htmlFor="performance" className="text-sm font-normal">
+          I&apos;m interested in performing publicly
+        </Label>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="message">Tell Us More</Label>
+        <Textarea
+          id="message"
+          placeholder="Share any additional details about what you're looking for, your vocal range, previous experience, etc."
+          rows={4}
+          value={formData.message}
+          onChange={(e) =>
+            setFormData((prev) => ({ ...prev, message: e.target.value }))
+          }
+        />
+      </div>
+
+      <Button
+        type="submit"
+        className="w-full"
+        size="lg"
+        disabled={isSubmitting}
+      >
+        {isSubmitting ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Submitting...
+          </>
+        ) : (
+          <>
+            Find My Group
+            <ArrowRight className="ml-2 h-4 w-4" />
+          </>
+        )}
+      </Button>
+
+      <p className="text-xs text-muted-foreground text-center">
+        By submitting, you agree to be contacted about singing group
+        opportunities. We respect your privacy and never share your information.
+      </p>
+    </form>
+  );
+}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -17,6 +17,7 @@ const navItems = [
   { label: "Coaching", href: "/coaching" },
   { label: "Workshops", href: "/workshops" },
   { label: "Speaking", href: "/speaking" },
+  { label: "Find a Group", href: "/find-group" },
   { label: "About", href: "/about" },
 ];
 


### PR DESCRIPTION
- Create /find-group landing page with hero, benefits, group types, how it works, FAQ, and CTA sections
- Add FindGroupForm component with fields for name, email, location, experience level, commitment, genre preferences, and performance interest
- Add "Find a Group" navigation link to header

This page allows users to submit requests to be matched with singing groups (a cappella, choirs, barbershop, community) based on their preferences and location.