### PR TITLE
fix: Wire Find a Group form to save submissions to database

### DIFF
--- a/src/app/dashboard/groups/page.tsx
+++ b/src/app/dashboard/groups/page.tsx
@@ -22,12 +22,12 @@ async function getGroupRequests(): Promise<{
   stats: { total: number; pending: number; responded: number }
 }> {
   try {
-    // Use inquiries with serviceType CONSULTATION or OTHER as group requests
+    // Use inquiries from find-group-form or with relevant keywords
     const inquiries = await prisma.inquiry.findMany({
       where: {
         OR: [
+          { lead: { source: 'find-group-form' } },
           { serviceType: 'CONSULTATION' },
-          { serviceType: 'OTHER' },
           { message: { contains: 'group', mode: 'insensitive' } },
           { message: { contains: 'sing', mode: 'insensitive' } },
         ],


### PR DESCRIPTION
The form was only logging to console and showing a fake success message. Now it properly:
- Creates/upserts a Lead via POST /api/leads
- Creates an Inquiry via POST /api/inquiries with all form details
- Stores preferences (genres, experience, commitment) in details JSON

Also updated dashboard query to filter by source='find-group-form'.