### PR TITLE
fix: Use explicit max-w-5xl without container class for Publications

### DIFF
--- a/src/components/landing/books-section.tsx
+++ b/src/components/landing/books-section.tsx
@@ -117,7 +117,7 @@ export function BooksSection() {
 
   return (
     <section className="py-16 md:py-20 bg-gradient-to-b from-background to-secondary/20 overflow-hidden">
-      <div className="container px-4 md:px-6">
+      <div className="w-full max-w-5xl mx-auto px-4 md:px-6">
         {/* Section Header */}
         <motion.div
           initial={{ opacity: 0, y: 20 }}


### PR DESCRIPTION
Tailwind v4's container class has built-in max-width that overrides custom max-width values. Removing container and using explicit w-full max-w-5xl mx-auto for true narrower centering.