### PR TITLE
fix: Handle single-name input in Find a Group form

### DIFF
--- a/src/components/find-group/find-group-form.tsx
+++ b/src/components/find-group/find-group-form.tsx
@@ -73,7 +73,7 @@ export function FindGroupForm() {
       // Parse name into first and last name
       const nameParts = formData.name.trim().split(/\s+/);
       const firstName = nameParts[0] || "";
-      const lastName = nameParts.slice(1).join(" ") || "";
+      const lastName = nameParts.slice(1).join(" ") || "(Not Provided)";
 
       // Step 1: Create or update lead
       const leadResponse = await fetch("/api/leads", {


### PR DESCRIPTION
When users enter only a first name (e.g., "Madonna"), the lastName field was becoming an empty string, causing Zod validation to fail with a 400 Bad Request error.

This commit provides a default value "(Not Provided)" for lastName when users don't provide a last name, ensuring the form submission passes validation and saves successfully.

Fixes the "Failed to create lead" error reported in production.