### PR TITLE
Swap hero portrait to higher-res deke_hi.jpg (3543x2338)

### DIFF
--- a/src/components/landing/hero-section.tsx
+++ b/src/components/landing/hero-section.tsx
@@ -161,8 +161,8 @@ export function HeroSection() {
             className="relative aspect-[3/4] rounded-2xl overflow-hidden hidden lg:block shadow-2xl"
           >
             <Image
-              src="/images/deke/deke2-photographer-Nikki-Davis-Jones.jpg"
-              alt="Deke Sharon - Professional Portrait"
+              src="/images/deke/deke_hi.jpg"
+              alt="Deke Sharon - Photo by Nikki Davis-Jones"
               fill
               className="object-cover"
               priority


### PR DESCRIPTION
The previous image (deke2-photographer-Nikki-Davis-Jones.jpg) was only 600x396 and looked pixelated when stretched in the hero section.

https://claude.ai/code/session_01EC1C8QYoZmbu4XrSLp4XW4