### PR TITLE
Update hero and video section images with new photos

### DIFF
--- a/src/components/landing/hero-section.tsx
+++ b/src/components/landing/hero-section.tsx
@@ -127,10 +127,10 @@ export function HeroSection() {
             className="relative aspect-[3/4] rounded-2xl overflow-hidden hidden lg:block shadow-2xl"
           >
             <Image
-              src="/images/deke/deke_hi.jpg"
-              alt="Deke Sharon - Photo by Nikki Davis-Jones"
+              src="/images/deke/biotop.jpg"
+              alt="Deke Sharon - Photo by Nina Westervelt"
               fill
-              className="object-cover"
+              className="object-cover object-top"
               priority
             />
             {/* Gradient overlay */}

--- a/src/components/landing/video-section.tsx
+++ b/src/components/landing/video-section.tsx
@@ -43,10 +43,10 @@ export function VideoSection() {
             aria-label="Play Deke Sharon highlight reel video"
             className="relative w-full aspect-video rounded-2xl overflow-hidden border border-border group cursor-pointer hover:border-accent/50 transition-all duration-300 shadow-lg hover:shadow-xl"
           >
-            {/* Video Thumbnail - Using Carnegie Hall image */}
+            {/* Video Thumbnail - Deke & Rebel Wilson in the studio */}
             <Image
-              src="/images/deke/big-img-41.jpg"
-              alt="Deke Sharon at Carnegie Hall"
+              src="/images/deke/big-img-21.jpg"
+              alt="Deke Sharon with Rebel Wilson in the recording studio"
               fill
               className="object-cover transition-transform duration-500 group-hover:scale-105"
             />


### PR DESCRIPTION
## Summary
Updated image assets and alt text in the landing page hero and video sections to use new photography.

## Key Changes
- **Hero Section**: Replaced hero image from `deke_hi.jpg` to `biotop.jpg` with updated photographer credit (Nina Westervelt instead of Nikki Davis-Jones)
- **Hero Section**: Added `object-top` positioning to the image to optimize vertical alignment of the new photo
- **Video Section**: Changed video thumbnail from Carnegie Hall image (`big-img-41.jpg`) to studio recording image (`big-img-21.jpg`)
- **Video Section**: Updated alt text to reflect new thumbnail content (Deke Sharon with Rebel Wilson in the recording studio)

## Implementation Details
- Image sources and alt text updated to maintain accessibility standards
- Object positioning adjusted on hero image to ensure proper display of the new photo
- Video section thumbnail now better represents the content with a studio collaboration image

https://claude.ai/code/session_01UzgttrHyxYwohvc3AnCSxe