### PR TITLE
Use rebel_wilso.png as video thumbnail without zoom

### DIFF
--- a/src/components/landing/video-section.tsx
+++ b/src/components/landing/video-section.tsx
@@ -43,12 +43,12 @@ export function VideoSection() {
             aria-label="Play Deke Sharon highlight reel video"
             className="relative w-full aspect-video rounded-2xl overflow-hidden border border-border group cursor-pointer hover:border-accent/50 transition-all duration-300 shadow-lg hover:shadow-xl"
           >
-            {/* Video Thumbnail - Deke & Rebel Wilson in the studio */}
+            {/* Video Thumbnail - Rebel Wilson interview */}
             <Image
-              src="/images/deke/big-img-21.jpg"
-              alt="Deke Sharon with Rebel Wilson in the recording studio"
+              src="/rebel_wilso.png"
+              alt="Rebel Wilson discussing working with Deke Sharon"
               fill
-              className="object-cover transition-transform duration-500 group-hover:scale-105"
+              className="object-cover"
             />
 
             {/* Dark overlay */}


### PR DESCRIPTION
- Switch video thumbnail to the Rebel Wilson interview screenshot
- Remove hover zoom-in effect on the thumbnail

https://claude.ai/code/session_01UzgttrHyxYwohvc3AnCSxe