### PR TITLE
Add notification debug endpoint and structured logging for troublesho…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,20 @@ TWILIO_AUTH_TOKEN="..."
 TWILIO_PHONE_NUMBER="+1..."
 
 # ============================================
+# CLOUDFLARE WORKER NOTIFICATIONS (Backup)
+# ============================================
+# Cloudflare Worker endpoint for backup email notifications via CF Email Routing
+CF_NOTIFICATION_WORKER_URL="https://your-worker.your-subdomain.workers.dev"
+# Shared secret for authenticating webhook calls to the Worker
+CF_NOTIFICATION_SECRET="your_webhook_secret_here"
+
+# ============================================
+# DEBUG (Optional)
+# ============================================
+# Secret for the /api/notifications/debug diagnostic endpoint
+DEBUG_SECRET="your_debug_secret_here"
+
+# ============================================
 # DEPLOYMENT
 # ============================================
 NODE_ENV="development"  # Railway sets this to "production"

--- a/scripts/test-notifications.sh
+++ b/scripts/test-notifications.sh
@@ -58,8 +58,7 @@ echo "4/4 - Booking request (/api/booking-request)..."
 curl -s -X POST "$BASE_URL/api/booking-request" \
   -H "Content-Type: application/json" \
   -d "{
-    \"firstName\": \"Test\",
-    \"lastName\": \"Booking\",
+    \"name\": \"Test Booking\",
     \"email\": \"test-booking-${TIMESTAMP}@example.com\",
     \"projectType\": \"workshop\",
     \"message\": \"Test booking request to verify admin notification.\",

--- a/src/app/api/notifications/debug/route.ts
+++ b/src/app/api/notifications/debug/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { Resend } from 'resend'
+import { sendCloudflareNotification } from '@/lib/notifications/cloudflare-notify'
+
+/**
+ * GET /api/notifications/debug?secret=<DEBUG_SECRET>
+ *
+ * Diagnostic endpoint to verify notification configuration and test delivery.
+ * Returns which env vars are set and attempts test sends via both channels.
+ */
+export async function GET(request: NextRequest) {
+  // Gate behind a secret to prevent abuse
+  const secret = request.nextUrl.searchParams.get('secret')
+  const debugSecret = process.env.DEBUG_SECRET
+
+  if (!debugSecret) {
+    return NextResponse.json(
+      { error: 'DEBUG_SECRET env var not set — add it to Railway to use this endpoint' },
+      { status: 503 }
+    )
+  }
+
+  if (secret !== debugSecret) {
+    return NextResponse.json({ error: 'Invalid secret' }, { status: 401 })
+  }
+
+  const resendApiKey = process.env.RESEND_API_KEY
+  const resendFromEmail = process.env.RESEND_FROM_EMAIL
+  const bookingEmails = process.env.BOOKING_NOTIFICATION_EMAILS
+  const cfWorkerUrl = process.env.CF_NOTIFICATION_WORKER_URL
+  const cfSecret = process.env.CF_NOTIFICATION_SECRET
+
+  // 1. Report env var status
+  const envVars = {
+    RESEND_API_KEY: !!resendApiKey,
+    RESEND_FROM_EMAIL: resendFromEmail || null,
+    BOOKING_NOTIFICATION_EMAILS: bookingEmails || '(using default: deke@dekesharon.com,denis@theagentfactory.ai)',
+    CF_NOTIFICATION_WORKER_URL: !!cfWorkerUrl,
+    CF_NOTIFICATION_SECRET: !!cfSecret,
+    NODE_ENV: process.env.NODE_ENV || 'not set',
+  }
+
+  // 2. Test Resend
+  let resendTest: { success: boolean; emailId?: string; error?: string }
+  if (!resendApiKey || !resendFromEmail) {
+    resendTest = {
+      success: false,
+      error: `Missing: ${[!resendApiKey && 'RESEND_API_KEY', !resendFromEmail && 'RESEND_FROM_EMAIL'].filter(Boolean).join(', ')}`,
+    }
+  } else {
+    try {
+      const resend = new Resend(resendApiKey)
+      const recipients = (bookingEmails || 'deke@dekesharon.com,denis@theagentfactory.ai')
+        .split(',')
+        .map((e: string) => e.trim())
+        .filter(Boolean)
+
+      const result = await resend.emails.send({
+        from: resendFromEmail,
+        to: recipients,
+        subject: 'Notification Debug Test — Deke Sharon Website',
+        html: `
+          <div style="font-family: sans-serif; padding: 20px;">
+            <h2>Notification System Debug Test</h2>
+            <p>This is an automated test from the <code>/api/notifications/debug</code> endpoint.</p>
+            <p>If you received this, <strong>Resend email delivery is working correctly.</strong></p>
+            <p style="color: #888; font-size: 12px;">Sent at: ${new Date().toISOString()}</p>
+          </div>
+        `,
+        tags: [{ name: 'type', value: 'debug_test' }],
+      })
+
+      if (result.error) {
+        resendTest = { success: false, error: result.error.message }
+      } else {
+        resendTest = { success: true, emailId: result.data?.id }
+      }
+    } catch (error) {
+      resendTest = {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+
+  // 3. Test Cloudflare Worker
+  let cloudflareTest: { success: boolean; error?: string }
+  try {
+    const cfResult = await sendCloudflareNotification({
+      type: 'contact',
+      name: 'Debug Test',
+      email: 'debug@test.local',
+      message: `Diagnostic test at ${new Date().toISOString()}`,
+    })
+    cloudflareTest = cfResult
+  } catch (error) {
+    cloudflareTest = {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+
+  return NextResponse.json({
+    timestamp: new Date().toISOString(),
+    envVars,
+    resendTest,
+    cloudflareTest,
+  })
+}

--- a/src/lib/notifications/booking-notification.ts
+++ b/src/lib/notifications/booking-notification.ts
@@ -249,9 +249,10 @@ export async function sendBookingNotification(
   const apiKey = process.env.RESEND_API_KEY
   const fromEmail = process.env.RESEND_FROM_EMAIL
 
-  // Check if email is configured
+  console.log('[NOTIFICATION:RESEND:BOOKING] Starting...', { bookingId: data.bookingId, serviceType: data.serviceType, to: NOTIFICATION_EMAILS, clientEmail: data.leadEmail })
+
   if (!apiKey || !fromEmail) {
-    console.warn('Email notifications not configured - RESEND_API_KEY or RESEND_FROM_EMAIL missing')
+    console.error('[NOTIFICATION:RESEND:BOOKING] NOT CONFIGURED — missing:', [!apiKey && 'RESEND_API_KEY', !fromEmail && 'RESEND_FROM_EMAIL'].filter(Boolean).join(', '))
     return {
       success: false,
       error: 'Email service not configured',
@@ -275,12 +276,12 @@ export async function sendBookingNotification(
     })
 
     if (adminResult.error) {
-      console.error('Failed to send admin notification:', adminResult.error)
+      console.error('[NOTIFICATION:RESEND:BOOKING] Admin email failed:', adminResult.error)
       results.error = adminResult.error.message
       results.success = false
     } else {
       results.adminEmailId = adminResult.data?.id
-      console.log(`Admin notification sent to ${NOTIFICATION_EMAILS.join(', ')}: ${results.adminEmailId}`)
+      console.log(`[NOTIFICATION:RESEND:BOOKING] Admin email sent to ${NOTIFICATION_EMAILS.join(', ')}: ${results.adminEmailId}`)
     }
 
     // Send client confirmation
@@ -296,19 +297,19 @@ export async function sendBookingNotification(
     })
 
     if (clientResult.error) {
-      console.error('Failed to send client confirmation:', clientResult.error)
+      console.error('[NOTIFICATION:RESEND:BOOKING] Client confirmation failed:', clientResult.error)
       // Don't fail the whole thing if only client email fails
       if (!results.error) {
         results.error = `Client email failed: ${clientResult.error.message}`
       }
     } else {
       results.clientEmailId = clientResult.data?.id
-      console.log(`Client confirmation sent successfully: ${results.clientEmailId}`)
+      console.log(`[NOTIFICATION:RESEND:BOOKING] Client confirmation sent: ${results.clientEmailId}`)
     }
 
     return results
   } catch (error) {
-    console.error('Booking notification error:', error)
+    console.error('[NOTIFICATION:RESEND:BOOKING] Error:', error)
     return {
       success: false,
       error: error instanceof Error ? error.message : 'Unknown error sending notifications',

--- a/src/lib/notifications/cloudflare-notify.ts
+++ b/src/lib/notifications/cloudflare-notify.ts
@@ -25,10 +25,10 @@ export interface FormNotificationData {
 export async function sendCloudflareNotification(
   data: FormNotificationData
 ): Promise<{ success: boolean; error?: string }> {
+  console.log('[NOTIFICATION:CF] Starting...', { type: data.type, name: data.name, workerConfigured: !!WORKER_URL, secretConfigured: !!WEBHOOK_SECRET });
+
   if (!WORKER_URL || !WEBHOOK_SECRET) {
-    console.warn(
-      'Cloudflare notification not configured — set CF_NOTIFICATION_WORKER_URL and CF_NOTIFICATION_SECRET'
-    );
+    console.error('[NOTIFICATION:CF] NOT CONFIGURED — missing:', [!WORKER_URL && 'CF_NOTIFICATION_WORKER_URL', !WEBHOOK_SECRET && 'CF_NOTIFICATION_SECRET'].filter(Boolean).join(', '));
     return { success: false, error: 'Not configured' };
   }
 
@@ -47,15 +47,15 @@ export async function sendCloudflareNotification(
 
     if (!response.ok) {
       const errorBody = await response.text();
-      console.error('Cloudflare notification failed:', response.status, errorBody);
+      console.error('[NOTIFICATION:CF] Worker returned error:', response.status, errorBody);
       return { success: false, error: `HTTP ${response.status}` };
     }
 
     const result = await response.json();
-    console.log('Cloudflare notification sent:', result);
+    console.log('[NOTIFICATION:CF] Sent successfully:', result);
     return { success: true };
   } catch (error) {
-    console.error('Cloudflare notification error:', error);
+    console.error('[NOTIFICATION:CF] Fetch error:', error);
     return {
       success: false,
       error: error instanceof Error ? error.message : 'Unknown error',

--- a/src/lib/notifications/signup-notification.ts
+++ b/src/lib/notifications/signup-notification.ts
@@ -123,8 +123,10 @@ export async function sendSignupNotification(
   const apiKey = process.env.RESEND_API_KEY
   const fromEmail = process.env.RESEND_FROM_EMAIL
 
+  console.log(`[NOTIFICATION:RESEND:SIGNUP] Starting (${data.type})...`, { name: data.name, email: data.email, to: NOTIFICATION_EMAILS })
+
   if (!apiKey || !fromEmail) {
-    console.warn('Email notifications not configured - RESEND_API_KEY or RESEND_FROM_EMAIL missing')
+    console.error('[NOTIFICATION:RESEND:SIGNUP] NOT CONFIGURED — missing:', [!apiKey && 'RESEND_API_KEY', !fromEmail && 'RESEND_FROM_EMAIL'].filter(Boolean).join(', '))
     return { success: false, error: 'Email service not configured' }
   }
 
@@ -143,14 +145,14 @@ export async function sendSignupNotification(
     })
 
     if (result.error) {
-      console.error(`Failed to send ${data.type} signup notification:`, result.error)
+      console.error(`[NOTIFICATION:RESEND:SIGNUP] ${data.type} failed:`, result.error)
       return { success: false, error: result.error.message }
     }
 
-    console.log(`Signup notification (${data.type}) sent to ${NOTIFICATION_EMAILS.join(', ')}: ${result.data?.id}`)
+    console.log(`[NOTIFICATION:RESEND:SIGNUP] ${data.type} sent to ${NOTIFICATION_EMAILS.join(', ')}: ${result.data?.id}`)
     return { success: true, adminEmailId: result.data?.id }
   } catch (error) {
-    console.error(`Signup notification error (${data.type}):`, error)
+    console.error(`[NOTIFICATION:RESEND:SIGNUP] ${data.type} error:`, error)
     return {
       success: false,
       error: error instanceof Error ? error.message : 'Unknown error sending notification',


### PR DESCRIPTION
…oting

Notifications are failing silently after deployment. This adds:
- GET /api/notifications/debug endpoint to check env var config and test both Resend and Cloudflare Worker delivery channels
- Structured [NOTIFICATION:*] log prefixes for easy Railway log filtering
- Missing CF_NOTIFICATION_WORKER_URL and CF_NOTIFICATION_SECRET to .env.example
- Fix test script sending wrong fields (firstName/lastName vs name) to booking API

https://claude.ai/code/session_018fDYX7EuytsiJhwNyH4EQg