### PR TITLE
Fix booking request crash on free-text event dates and await notifica…

### DIFF
--- a/src/app/api/booking-request/route.ts
+++ b/src/app/api/booking-request/route.ts
@@ -98,16 +98,25 @@ export async function POST(request: NextRequest) {
     });
 
     // Step 3: Create Booking Request (pending status)
+    // Parse eventDate safely — it's a free-text field so only use it if it's a valid date
+    let parsedDate: Date | null = null;
+    if (eventDate) {
+      const d = new Date(eventDate);
+      if (!isNaN(d.getTime())) {
+        parsedDate = d;
+      }
+    }
+
     const booking = await prisma.booking.create({
       data: {
         leadId: lead.id,
         inquiryId: inquiry.id,
         serviceType,
         status: "PENDING",
-        startDate: eventDate ? new Date(eventDate) : null,
+        startDate: parsedDate,
         paymentStatus: "UNPAID",
         clientNotes: message,
-        internalNotes: budget ? `Budget: ${budget}` : null,
+        internalNotes: [budget ? `Budget: ${budget}` : null, eventDate && !parsedDate ? `Preferred dates: ${eventDate}` : null].filter(Boolean).join('\n') || null,
       },
       include: {
         lead: {
@@ -124,36 +133,39 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    // Send booking notification emails (async - don't block response)
-    sendBookingNotification({
-      bookingId: booking.id,
-      leadName: `${booking.lead.firstName} ${booking.lead.lastName}`,
-      leadEmail: booking.lead.email,
-      leadPhone: booking.lead.phone,
-      organization: booking.lead.organization,
-      serviceType: booking.serviceType,
-      startDate: booking.startDate,
-      location: null,
-      amount: null,
-      clientNotes: booking.clientNotes,
-    }).catch((error) => {
-      console.error("Failed to send booking notification:", error);
-    });
+    // Send notifications — await both so they complete before the response
+    const [resendResult, cfResult] = await Promise.allSettled([
+      sendBookingNotification({
+        bookingId: booking.id,
+        leadName: `${booking.lead.firstName} ${booking.lead.lastName}`,
+        leadEmail: booking.lead.email,
+        leadPhone: booking.lead.phone,
+        organization: booking.lead.organization,
+        serviceType: booking.serviceType,
+        startDate: booking.startDate,
+        location: null,
+        amount: null,
+        clientNotes: booking.clientNotes,
+      }),
+      sendCloudflareNotification({
+        type: 'booking_request',
+        name,
+        email,
+        phone: phone || undefined,
+        organization: organization || undefined,
+        serviceType: projectType,
+        eventDate: eventDate || undefined,
+        budget: budget || undefined,
+        message: message || undefined,
+      }),
+    ]);
 
-    // Also notify via Cloudflare Worker (independent backup)
-    sendCloudflareNotification({
-      type: 'booking_request',
-      name,
-      email,
-      phone: phone || undefined,
-      organization: organization || undefined,
-      serviceType: projectType,
-      eventDate: eventDate || undefined,
-      budget: budget || undefined,
-      message: message || undefined,
-    }).catch((error) => {
-      console.error("Failed to send Cloudflare notification:", error);
-    });
+    if (resendResult.status === 'rejected') {
+      console.error("[BOOKING-REQUEST] Resend notification threw:", resendResult.reason);
+    }
+    if (cfResult.status === 'rejected') {
+      console.error("[BOOKING-REQUEST] Cloudflare notification threw:", cfResult.reason);
+    }
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -52,21 +52,28 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    // Send admin notification (fire-and-forget)
-    sendSignupNotification({
-      type: 'contact',
-      name: `${firstName} ${lastName}`,
-      email,
-      message: `Subject: ${subject}\n\n${message}`,
-    }).catch(err => console.error('Contact notification failed:', err));
+    // Send notifications — await both so they complete before the response
+    const [resendResult, cfResult] = await Promise.allSettled([
+      sendSignupNotification({
+        type: 'contact',
+        name: `${firstName} ${lastName}`,
+        email,
+        message: `Subject: ${subject}\n\n${message}`,
+      }),
+      sendCloudflareNotification({
+        type: 'contact',
+        name: `${firstName} ${lastName}`,
+        email,
+        message: `Subject: ${subject}\n\n${message}`,
+      }),
+    ]);
 
-    // Also notify via Cloudflare Worker (independent backup)
-    sendCloudflareNotification({
-      type: 'contact',
-      name: `${firstName} ${lastName}`,
-      email,
-      message: `Subject: ${subject}\n\n${message}`,
-    }).catch(err => console.error('Cloudflare notification failed:', err));
+    if (resendResult.status === 'rejected') {
+      console.error("[CONTACT] Resend notification threw:", resendResult.reason);
+    }
+    if (cfResult.status === 'rejected') {
+      console.error("[CONTACT] Cloudflare notification threw:", cfResult.reason);
+    }
 
     return NextResponse.json({
       success: true,


### PR DESCRIPTION
…tions

The eventDate field is free-text (e.g. "Saturdays in April") but was passed directly to new Date(), causing Invalid Date which crashes Prisma's booking create. This silently killed the entire request before notifications fired.

Now parses dates safely — invalid dates stored in internalNotes instead. Also switches both routes from fire-and-forget to Promise.allSettled so notifications complete before the response and failures are logged.

https://claude.ai/code/session_018fDYX7EuytsiJhwNyH4EQg