### PR TITLE
Add CURATOR agent and pipeline hardening to improve lead quality

### DIFF
--- a/agents/curator/evaluator.ts
+++ b/agents/curator/evaluator.ts
@@ -1,0 +1,165 @@
+/**
+ * CURATOR Lead Quality Evaluator
+ *
+ * Uses Claude Haiku to batch-evaluate lead relevance to Deke Sharon's services.
+ * Returns structured quality scores and reasoning for each lead.
+ */
+
+import Anthropic from '@anthropic-ai/sdk'
+
+const anthropic = new Anthropic({
+  apiKey: process.env.ANTHROPIC_API_KEY,
+})
+
+const QUALITY_THRESHOLD = 50
+const BATCH_SIZE = 15
+
+export interface LeadForEvaluation {
+  id: string
+  campaignLeadId: string
+  firstName: string
+  lastName: string
+  email: string
+  organization: string | null
+  source: string
+  score: number
+  contactTitle: string | null
+  website: string | null
+  editorialSummary: string | null
+  googleRating: number | null
+}
+
+interface CampaignContext {
+  name: string
+  baseLocation: string
+  radius: number
+  targetOrgTypes: string | null
+}
+
+export interface QualityResult {
+  campaignLeadId: string
+  qualityScore: number
+  qualityPassed: boolean
+  qualityReason: string
+}
+
+const SYSTEM_PROMPT = `You are a lead quality evaluator for Deke Sharon, the "Father of Contemporary A Cappella."
+
+Deke's services:
+- A cappella workshops & clinics for choirs, schools, and festivals
+- Vocal group coaching (in-person and virtual)
+- Individual vocal coaching
+- Custom vocal arrangements ($500-$3,000+)
+- Keynote speaking on music, teamwork, and creativity
+- Masterclasses for music educators
+
+EVALUATE each lead on whether they would genuinely benefit from and potentially purchase Deke's services.
+
+HIGH QUALITY leads (score 70-100):
+- Choirs, choruses, a cappella groups, vocal ensembles
+- Music schools, conservatories, university music departments
+- Choral festivals, music conferences, arts organizations
+- Sweet Adelines, Barbershop Harmony Society, CASA chapters
+- School music programs (high school, college)
+- Decision-makers with relevant titles (Music Director, Choir Director, etc.)
+
+MEDIUM QUALITY leads (score 40-69):
+- General performing arts organizations
+- Churches with active music programs
+- Community music organizations
+- Generic contact info but relevant organization
+
+LOW QUALITY leads (score 0-39):
+- Non-music businesses that happen to have "music" in the name
+- Record stores, instrument shops, music equipment retailers
+- Barbershops (haircuts, not singing)
+- Organizations with no clear connection to vocal music
+- Leads with placeholder/fake contact info
+- Generic community centers without music focus
+
+You MUST respond with valid JSON only. No markdown, no explanation outside the JSON.`
+
+function buildUserPrompt(
+  leads: LeadForEvaluation[],
+  campaign: CampaignContext
+): string {
+  const leadsData = leads.map((l) => ({
+    campaignLeadId: l.campaignLeadId,
+    name: `${l.firstName} ${l.lastName}`,
+    email: l.email,
+    organization: l.organization,
+    source: l.source,
+    discoveryScore: l.score,
+    contactTitle: l.contactTitle,
+    website: l.website,
+    description: l.editorialSummary,
+    googleRating: l.googleRating,
+  }))
+
+  return `Campaign: "${campaign.name}" targeting ${campaign.baseLocation} (${campaign.radius} mile radius)
+${campaign.targetOrgTypes ? `Target org types: ${campaign.targetOrgTypes}` : ''}
+
+Evaluate these ${leads.length} leads. For each, provide:
+- qualityScore (0-100)
+- qualityPassed (true if score >= ${QUALITY_THRESHOLD})
+- qualityReason (one sentence explaining the score)
+
+Respond with JSON: { "leads": [{ "campaignLeadId": "...", "qualityScore": N, "qualityPassed": bool, "qualityReason": "..." }] }
+
+Leads to evaluate:
+${JSON.stringify(leadsData, null, 2)}`
+}
+
+/**
+ * Evaluate a batch of leads using Claude Haiku
+ */
+export async function evaluateLeadBatch(
+  leads: LeadForEvaluation[],
+  campaign: CampaignContext
+): Promise<QualityResult[]> {
+  if (leads.length === 0) return []
+
+  try {
+    const response = await anthropic.messages.create({
+      model: 'claude-3-haiku-20240307',
+      max_tokens: 2048,
+      system: SYSTEM_PROMPT,
+      messages: [
+        { role: 'user', content: buildUserPrompt(leads, campaign) },
+      ],
+    })
+
+    const text =
+      response.content[0].type === 'text' ? response.content[0].text : ''
+
+    const parsed = JSON.parse(text) as { leads: QualityResult[] }
+
+    // Validate and normalize results
+    return parsed.leads.map((result) => ({
+      campaignLeadId: result.campaignLeadId,
+      qualityScore: Math.min(100, Math.max(0, result.qualityScore || 0)),
+      qualityPassed: result.qualityScore >= QUALITY_THRESHOLD,
+      qualityReason: result.qualityReason || 'No reason provided',
+    }))
+  } catch (error) {
+    console.error('[CURATOR:Evaluator] Batch evaluation failed:', error)
+    // On failure, don't block — return null results so leads aren't gated
+    return leads.map((lead) => ({
+      campaignLeadId: lead.campaignLeadId,
+      qualityScore: 0,
+      qualityPassed: false,
+      qualityReason: 'Evaluation failed — manual review required',
+    }))
+  }
+}
+
+/**
+ * Split leads into batches for evaluation
+ */
+export function batchLeads<T>(leads: T[]): T[][] {
+  const batches: T[][] = []
+  for (let i = 0; i < leads.length; i += BATCH_SIZE) {
+    batches.push(leads.slice(i, i + BATCH_SIZE))
+  }
+  return batches
+}

--- a/agents/curator/index.ts
+++ b/agents/curator/index.ts
@@ -1,0 +1,220 @@
+/**
+ * CURATOR Agent - Lead Quality Evaluator
+ *
+ * Uses Claude AI to evaluate lead quality before outreach.
+ * Subscribes to discovery_completed events and automatically
+ * assesses all new leads, storing quality scores in the database.
+ */
+
+import { BaseAgent } from '../base-agent'
+import { eventBus } from '@/lib/event-bus'
+import { prisma } from '@/lib/db'
+import type { AgentConfig, AgentResponse, AgentEvent } from '../types'
+import {
+  evaluateLeadBatch,
+  batchLeads,
+  type QualityResult,
+  type LeadForEvaluation,
+} from './evaluator'
+
+const CURATOR_CONFIG: AgentConfig = {
+  id: 'curator',
+  name: 'CURATOR',
+  tier: 'intelligence',
+  description:
+    'Lead quality evaluator - uses AI to assess lead relevance before outreach',
+  systemPrompt: `You are CURATOR, Deke Sharon's lead quality specialist.
+
+Your mission:
+- Evaluate every discovered lead for genuine relevance to Deke's services
+- Filter out "AI slop" — irrelevant businesses, wrong contacts, non-music orgs
+- Ensure only high-quality leads receive outreach
+- Provide clear reasoning for quality scores
+
+Quality standards:
+- Score 70+: Strong fit — choirs, a cappella groups, music schools, festivals
+- Score 50-69: Moderate fit — arts orgs, churches with music programs
+- Score below 50: Poor fit — rejected from outreach
+- Never pass leads with placeholder emails or fake contact names
+
+Be rigorous. One well-targeted email beats ten generic ones.`,
+  tools: [],
+}
+
+export class CURATORAgent extends BaseAgent {
+  constructor() {
+    super(CURATOR_CONFIG)
+    this.initializeHandlers()
+  }
+
+  private initializeHandlers(): void {
+    // Auto-evaluate after discovery completes
+    eventBus.subscribe(
+      'discovery_completed',
+      async (event: AgentEvent) => {
+        await this.handleDiscoveryCompleted(event)
+      }
+    )
+
+    // Manual evaluation request
+    eventBus.subscribe(
+      'evaluate_leads',
+      async (event: AgentEvent) => {
+        if (event.targetAgent === 'curator') {
+          await this.handleEvaluateRequest(event)
+        }
+      }
+    )
+  }
+
+  private async handleDiscoveryCompleted(event: AgentEvent): Promise<void> {
+    const campaignId = event.payload.campaignId as string
+    if (!campaignId) {
+      console.error('[CURATOR] discovery_completed event missing campaignId')
+      return
+    }
+
+    console.log(
+      `[CURATOR] Discovery completed for campaign ${campaignId}, starting quality evaluation`
+    )
+    await this.evaluateCampaignLeads(campaignId)
+  }
+
+  private async handleEvaluateRequest(event: AgentEvent): Promise<void> {
+    const campaignId = event.payload.campaignId as string
+    if (!campaignId) {
+      console.error('[CURATOR] evaluate_leads event missing campaignId')
+      return
+    }
+
+    console.log(
+      `[CURATOR] Manual evaluation requested for campaign ${campaignId}`
+    )
+    await this.evaluateCampaignLeads(campaignId)
+  }
+
+  /**
+   * Evaluate all unevaluated leads in a campaign
+   */
+  async evaluateCampaignLeads(campaignId: string): Promise<{
+    evaluated: number
+    passed: number
+    failed: number
+  }> {
+    // Fetch campaign context
+    const campaign = await prisma.campaign.findUnique({
+      where: { id: campaignId },
+    })
+
+    if (!campaign) {
+      console.error(`[CURATOR] Campaign ${campaignId} not found`)
+      return { evaluated: 0, passed: 0, failed: 0 }
+    }
+
+    // Fetch unevaluated campaign leads with lead data
+    const campaignLeads = await prisma.campaignLead.findMany({
+      where: {
+        campaignId,
+        qualityEvaluatedAt: null,
+      },
+      include: {
+        lead: true,
+      },
+    })
+
+    if (campaignLeads.length === 0) {
+      console.log(`[CURATOR] No unevaluated leads for campaign ${campaignId}`)
+      return { evaluated: 0, passed: 0, failed: 0 }
+    }
+
+    console.log(
+      `[CURATOR] Evaluating ${campaignLeads.length} leads for campaign ${campaignId}`
+    )
+
+    // Prepare leads for evaluation
+    const leadsForEval: LeadForEvaluation[] = campaignLeads.map((cl: any) => ({
+      id: cl.lead.id,
+      campaignLeadId: cl.id,
+      firstName: cl.lead.firstName,
+      lastName: cl.lead.lastName,
+      email: cl.lead.email,
+      organization: cl.lead.organization,
+      source: cl.source,
+      score: cl.score,
+      contactTitle: cl.lead.contactTitle,
+      website: cl.lead.website,
+      editorialSummary: cl.lead.editorialSummary,
+      googleRating: cl.lead.googleRating,
+    }))
+
+    // Batch and evaluate
+    const batches = batchLeads(leadsForEval)
+    const allResults: QualityResult[] = []
+
+    const campaignContext = {
+      name: campaign.name,
+      baseLocation: campaign.baseLocation,
+      radius: campaign.radius,
+      targetOrgTypes: campaign.targetOrgTypes,
+    }
+
+    for (const batch of batches) {
+      const results = await evaluateLeadBatch(batch, campaignContext)
+      allResults.push(...results)
+    }
+
+    // Update database with results
+    const now = new Date()
+    let passed = 0
+    let failed = 0
+
+    for (const result of allResults) {
+      try {
+        await prisma.campaignLead.update({
+          where: { id: result.campaignLeadId },
+          data: {
+            qualityScore: result.qualityScore,
+            qualityReason: result.qualityReason,
+            qualityPassed: result.qualityPassed,
+            qualityEvaluatedAt: now,
+          },
+        })
+        if (result.qualityPassed) passed++
+        else failed++
+      } catch (updateError) {
+        console.error(
+          `[CURATOR] Failed to update lead ${result.campaignLeadId}:`,
+          updateError
+        )
+      }
+    }
+
+    console.log(
+      `[CURATOR] Evaluation complete: ${allResults.length} evaluated, ${passed} passed, ${failed} failed`
+    )
+
+    // Emit completion event
+    await this.emitEvent('quality_evaluation_completed', {
+      campaignId,
+      evaluated: allResults.length,
+      passed,
+      failed,
+    })
+
+    return { evaluated: allResults.length, passed, failed }
+  }
+
+  async processMessage(message: string): Promise<AgentResponse> {
+    return {
+      message:
+        "CURATOR here! I evaluate lead quality using AI to ensure only relevant, high-quality leads receive outreach. I'm triggered automatically after discovery completes.",
+      metadata: {
+        status: 'active',
+        agent: 'curator',
+      },
+    }
+  }
+}
+
+// Export singleton instance
+export const curatorAgent = new CURATORAgent()

--- a/agents/index.ts
+++ b/agents/index.ts
@@ -9,6 +9,7 @@ import { harmonyAgent } from './harmony';
 import { maestroAgent } from './maestro';
 import { conductorAgent } from './conductor';
 import { scoutAgent } from './scout';
+import { curatorAgent } from './curator';
 
 // Export all agents
 export const agents = {
@@ -16,6 +17,7 @@ export const agents = {
   maestro: maestroAgent,
   conductor: conductorAgent,
   scout: scoutAgent,
+  curator: curatorAgent,
 } as const;
 
 // Type for agent IDs

--- a/agents/types.ts
+++ b/agents/types.ts
@@ -15,7 +15,8 @@ export type AgentId =
   | 'scribe'       // Content creation
   | 'repertoire'   // Song recommendations
   | 'metrics'      // Analytics dashboard
-  | 'scout';       // Opportunity finder
+  | 'scout'        // Opportunity finder
+  | 'curator';     // Lead quality evaluator
 
 // Agent Tiers
 export type AgentTier =

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -510,6 +510,12 @@ model CampaignLead {
   recommendationReason String?  // Why these services? (for template variables)
   recommendationScore  Int?     // 0-15 bonus from recommendations
 
+  // Lead quality evaluation (CURATOR agent)
+  qualityScore        Int?         // 0-100 AI-assessed quality
+  qualityReason       String?      // Why this quality score
+  qualityPassed       Boolean?     // Passes minimum quality gate
+  qualityEvaluatedAt  DateTime?    // When CURATOR last evaluated
+
   // Phase 6: Follow-up automation
   scheduledFollowUpDate  DateTime?  // When next follow-up should be sent
   followUpCount          Int        @default(0)  // How many follow-ups sent (0, 1, 2)

--- a/src/app/api/campaigns/[id]/evaluate-quality/route.ts
+++ b/src/app/api/campaigns/[id]/evaluate-quality/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { handleApiError, ApiError } from '@/lib/api-error'
+import { curatorAgent } from '../../../../../agents/curator'
+
+/**
+ * POST /api/campaigns/[id]/evaluate-quality
+ *
+ * Triggers CURATOR agent to evaluate lead quality for a campaign.
+ * Can be called manually before generating drafts to ensure
+ * only quality leads receive outreach.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: campaignId } = await params
+
+    // Verify campaign exists
+    const campaign = await prisma.campaign.findUnique({
+      where: { id: campaignId },
+    })
+    if (!campaign) {
+      throw new ApiError(404, 'Campaign not found', 'NOT_FOUND')
+    }
+
+    // Check if there are leads to evaluate
+    const unevaluatedCount = await prisma.campaignLead.count({
+      where: {
+        campaignId,
+        qualityEvaluatedAt: null,
+      },
+    })
+
+    if (unevaluatedCount === 0) {
+      // Check total leads to give helpful message
+      const totalLeads = await prisma.campaignLead.count({
+        where: { campaignId },
+      })
+
+      if (totalLeads === 0) {
+        throw new ApiError(
+          400,
+          'No leads found — run discovery first',
+          'NO_LEADS'
+        )
+      }
+
+      return NextResponse.json({
+        message: 'All leads have already been evaluated',
+        evaluated: 0,
+        passed: 0,
+        failed: 0,
+      })
+    }
+
+    // Run CURATOR evaluation
+    const result = await curatorAgent.evaluateCampaignLeads(campaignId)
+
+    return NextResponse.json({
+      message: `Quality evaluation complete: ${result.passed} passed, ${result.failed} failed out of ${result.evaluated} leads`,
+      ...result,
+    })
+  } catch (error) {
+    return handleApiError(error)
+  }
+}

--- a/src/app/api/campaigns/[id]/generate-drafts/route.ts
+++ b/src/app/api/campaigns/[id]/generate-drafts/route.ts
@@ -59,11 +59,29 @@ export async function POST(
       throw new ApiError(400, 'No matching campaign leads found', 'NO_LEADS')
     }
 
+    // Quality gate: filter out leads that shouldn't receive drafts
+    const genericPrefixes = ['info@', 'hello@', 'contact@', 'admin@', 'office@', 'general@']
+    const draftableLeads = campaignLeads.filter((cl: any) => {
+      // No placeholder emails
+      if (cl.lead.email?.includes('@placeholder.local')) return false
+      // No fake "Contact at Org" names from unenriched leads
+      if (cl.lead.firstName === 'Contact' && cl.lead.lastName?.startsWith('at ')) return false
+      // For cold leads, reject generic-only emails (info@, hello@, etc.)
+      if (cl.source === 'AI_RESEARCH') {
+        if (genericPrefixes.some(p => cl.lead.email?.startsWith(p))) return false
+      }
+      // Gate on CURATOR quality evaluation if it has been run
+      if (cl.qualityPassed === false) return false
+      return true
+    })
+
+    const qualityFiltered = campaignLeads.length - draftableLeads.length
+
     // Check which already have drafts
     const existingDrafts = await prisma.emailDraft.findMany({
       where: {
         campaignId,
-        campaignLeadId: { in: campaignLeads.map(cl => cl.id) },
+        campaignLeadId: { in: draftableLeads.map(cl => cl.id) },
       },
       select: { campaignLeadId: true },
     })
@@ -72,7 +90,7 @@ export async function POST(
     let created = 0
     let skipped = 0
 
-    for (const cl of campaignLeads) {
+    for (const cl of draftableLeads) {
       if (existingIds.has(cl.id)) {
         skipped++
         continue
@@ -102,7 +120,7 @@ export async function POST(
       created++
     }
 
-    return NextResponse.json({ created, skipped })
+    return NextResponse.json({ created, skipped, qualityFiltered })
   } catch (error) {
     return handleApiError(error)
   }

--- a/src/lib/discovery/ai-research.ts
+++ b/src/lib/discovery/ai-research.ts
@@ -327,8 +327,9 @@ export async function discoverAIResearch(campaign: Campaign): Promise<AIResearch
     }
   })
 
-  // Filter: ONLY organizations with music relevance (score > 0)
-  const musicOrgs = scoredPlaces.filter((p) => p.musicScore > 0)
+  // Filter: ONLY organizations with strong music relevance (score >= 10)
+  // Requires at least one real music signal (choir/chorus=20, music education=15, youth program=10)
+  const musicOrgs = scoredPlaces.filter((p) => p.musicScore >= 10)
   diagnostics.musicRelevant = musicOrgs.length
 
   const filteredOut = uniquePlaces.length - musicOrgs.length

--- a/src/lib/discovery/orchestrator.ts
+++ b/src/lib/discovery/orchestrator.ts
@@ -6,6 +6,7 @@
  */
 
 import { prisma } from '@/lib/db'
+import { eventBus } from '@/lib/event-bus'
 import { discoverPastClients } from './past-clients'
 import { discoverDormantLeads } from './dormant-leads'
 import { discoverSimilarOrgs } from './similar-orgs'
@@ -15,6 +16,10 @@ import { deduplicate, getDeduplicationStats } from './deduplicator'
 import { classifyOrganization } from './org-classifier'
 import { getRecommendations, buildRecommendationReason } from '@/lib/recommendations/engine'
 import { calculateRecommendationBonus } from '@/lib/recommendations/scorer'
+
+// Minimum score thresholds for quality gate
+const COLD_SCORE_THRESHOLD = 40
+const WARM_SCORE_THRESHOLD = 25
 
 export interface SourceDiagnostic {
   source: string
@@ -26,6 +31,7 @@ export interface SourceDiagnostic {
 
 export interface DiscoveryResult {
   total: number
+  filteredOut: number
   bySource: {
     PAST_CLIENT: number
     DORMANT: number
@@ -247,19 +253,36 @@ export async function discoverLeads(campaignId: string): Promise<DiscoveryResult
     score: calculateScore(lead, campaign) + (lead.recommendationBonus || 0),
   }))
 
-  // Calculate score statistics
-  const scores = scored.map((lead) => lead.score)
+  // Quality gate: reject low-score and unenriched leads
+  const qualityFiltered = scored.filter((lead) => {
+    // Reject placeholder emails
+    if ((lead as any).email?.includes('@placeholder.local')) return false
+    if ((lead as any).needsEnrichment) return false
+
+    // Enforce minimum score by source
+    const threshold = lead.source === 'AI_RESEARCH' ? COLD_SCORE_THRESHOLD : WARM_SCORE_THRESHOLD
+    return lead.score >= threshold
+  })
+
+  const filteredOutCount = scored.length - qualityFiltered.length
+  if (filteredOutCount > 0) {
+    console.log(`[Discovery:Orchestrator] Quality gate filtered out ${filteredOutCount} leads (score threshold or placeholder email)`)
+    warnings.push(`${filteredOutCount} leads filtered out by quality gate (score < ${COLD_SCORE_THRESHOLD} for cold / ${WARM_SCORE_THRESHOLD} for warm, or placeholder email)`)
+  }
+
+  // Calculate score statistics (on filtered leads)
+  const scores = qualityFiltered.map((lead) => lead.score)
   const scoreStats = calculateScoreStats(scores)
   const avgScore = scores.length > 0 ? scores.reduce((sum, s) => sum + s, 0) / scores.length : 0
 
   // Insert CampaignLead records in database
   // For SQLite compatibility, filter out existing campaign-lead pairs before inserting
-  if (scored.length > 0) {
+  if (qualityFiltered.length > 0) {
     // Get existing campaign-lead pairs to avoid duplicates
     const existingPairs = await prisma.campaignLead.findMany({
       where: {
         campaignId: campaign.id,
-        leadId: { in: scored.map((lead) => lead.id) },
+        leadId: { in: qualityFiltered.map((lead) => lead.id) },
       },
       select: {
         leadId: true,
@@ -269,7 +292,7 @@ export async function discoverLeads(campaignId: string): Promise<DiscoveryResult
     const existingLeadIds = new Set(existingPairs.map((pair) => pair.leadId))
 
     // Filter out leads that are already in the campaign
-    const newLeads = scored.filter((lead) => !existingLeadIds.has(lead.id))
+    const newLeads = qualityFiltered.filter((lead) => !existingLeadIds.has(lead.id))
 
     // Insert only new leads
     if (newLeads.length > 0) {
@@ -300,10 +323,29 @@ export async function discoverLeads(campaignId: string): Promise<DiscoveryResult
     console.warn('[Discovery:Orchestrator] Warnings:', warnings)
   }
 
-  console.log(`[Discovery:Orchestrator] Complete: ${scored.length} leads in ${duration}ms`)
+  console.log(`[Discovery:Orchestrator] Complete: ${qualityFiltered.length} leads in ${duration}ms (${filteredOutCount} filtered out)`)
+
+  // Emit discovery_completed event to trigger CURATOR quality evaluation
+  try {
+    await eventBus.emit({
+      eventId: crypto.randomUUID(),
+      sourceAgent: 'scout',
+      eventType: 'discovery_completed',
+      payload: {
+        campaignId: campaign.id,
+        totalLeads: qualityFiltered.length,
+        filteredOut: filteredOutCount,
+        avgScore: Math.round(avgScore * 10) / 10,
+      },
+      timestamp: new Date(),
+    })
+  } catch (eventError) {
+    console.error('[Discovery:Orchestrator] Failed to emit discovery_completed event:', eventError)
+  }
 
   return {
-    total: scored.length,
+    total: qualityFiltered.length,
+    filteredOut: filteredOutCount,
     bySource,
     avgScore: Math.round(avgScore * 10) / 10, // Round to 1 decimal
     scoreStats,


### PR DESCRIPTION
Addresses low-quality leads ("AI slop") coming from campaign discovery by adding a two-pronged quality system:

Pipeline hardening (deterministic):
- Minimum score threshold: 40 for cold leads, 25 for warm leads
- Reject placeholder emails and unenriched leads before DB insertion
- Raise music relevance floor from >0 to >=10 in Google Places filtering
- Block drafts for fake names, generic emails, and failed quality checks

CURATOR agent (AI-powered):
- New intelligence-tier agent using Claude Haiku for lead quality evaluation
- Auto-triggers via EventBus on discovery_completed events
- Batch evaluates leads (15/batch) for relevance to Deke's services
- Stores qualityScore, qualityReason, qualityPassed on CampaignLead
- Manual evaluation endpoint: POST /api/campaigns/[id]/evaluate-quality
- Draft generation gates on qualityPassed flag

https://claude.ai/code/session_018cHrwXEoRCW6DzaeKQSAtW