### PR TITLE
Fix evaluate-quality route: use @agents path alias instead of relativ…

### DIFF
--- a/src/app/api/campaigns/[id]/evaluate-quality/route.ts
+++ b/src/app/api/campaigns/[id]/evaluate-quality/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { handleApiError, ApiError } from '@/lib/api-error'
-import { curatorAgent } from '../../../../../agents/curator'
+import { curatorAgent } from '@agents/curator'
 
 /**
  * POST /api/campaigns/[id]/evaluate-quality


### PR DESCRIPTION
…e import

The relative import '../../../../../agents/curator' fails to resolve during Turbopack build. Use the @agents/* path alias (added in tsconfig.json) for reliable module resolution.

https://claude.ai/code/session_018cHrwXEoRCW6DzaeKQSAtW