### PR TITLE
Fix campaign 500/400 errors: add db push to build and fix approve sta…

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && next build",
+    "build": "prisma generate && prisma db push --skip-generate && next build",
     "start": "next start",
     "lint": "eslint",
     "type-check": "tsc --noEmit",

--- a/src/app/api/campaigns/[id]/approve/route.ts
+++ b/src/app/api/campaigns/[id]/approve/route.ts
@@ -35,10 +35,10 @@ export async function POST(
     }
 
     // Validate campaign can be approved
-    if (campaign.status !== 'DRAFT') {
+    if (campaign.status !== 'DRAFT' && campaign.status !== 'READY') {
       throw new ApiError(
         400,
-        'Only draft campaigns can be approved',
+        'Only draft or ready campaigns can be approved',
         'INVALID_STATUS'
       )
     }


### PR DESCRIPTION
…tus check

Two issues:
1. GET /api/campaigns/[id] returns 500 because new CampaignLead quality columns (qualityScore, qualityReason, etc.) were added to schema.prisma but never applied to the production database. Added `prisma db push --skip-generate` to the build script so schema changes auto-apply on deploy.

2. POST /api/campaigns/[id]/approve returns 400 because the discover route sets campaign status to READY, but approve only allowed DRAFT. Now approve accepts both DRAFT and READY status.

https://claude.ai/code/session_018cHrwXEoRCW6DzaeKQSAtW