### PR TITLE
Massively improve lead discovery: pagination, Perplexity AI, quality …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,15 @@ ANTHROPIC_API_KEY="sk-ant-api03-..."
 GOOGLE_PLACES_API_KEY="your_google_places_api_key_here"
 
 # ============================================
+# PERPLEXITY AI (for comprehensive lead discovery)
+# ============================================
+# Get your API key: https://www.perplexity.ai/settings/api
+# Uses Sonar model to find choirs/a cappella groups that Google Places misses
+# Pricing: ~$5/1000 searches (very affordable)
+# Optional: If not set, Perplexity discovery will be skipped (graceful degradation)
+PERPLEXITY_API_KEY="pplx-..."
+
+# ============================================
 # EMAIL & SMS (Optional)
 # ============================================
 RESEND_API_KEY="re_..."

--- a/src/lib/discovery/ai-research.ts
+++ b/src/lib/discovery/ai-research.ts
@@ -272,9 +272,9 @@ export async function discoverAIResearch(campaign: Campaign): Promise<AIResearch
   const allPlaces: any[] = []
 
   // Convert radius from miles to meters (Places API uses meters)
-  // Google Text Search query includes location name, so it covers the area well
-  // even beyond the 50km radius parameter limit
-  const radiusMeters = Math.min(campaign.radius * 1609.34, 50000)
+  // Text Search with location bias uses radius as a preference, not a hard limit,
+  // so we pass the full radius. The query includes location name for additional targeting.
+  const radiusMeters = Math.round(campaign.radius * 1609.34)
 
   console.log(`[AI Research] Starting search: ${MUSIC_KEYWORDS.length} keywords, radius=${radiusMeters}m, location="${campaign.baseLocation}" (${campaign.latitude}, ${campaign.longitude})`)
 
@@ -293,7 +293,8 @@ export async function discoverAIResearch(campaign: Campaign): Promise<AIResearch
         campaign.baseLocation,
         radiusMeters,
         keyword,
-        apiKey
+        apiKey,
+        diagnostics
       )
       diagnostics.keywordResults.push({ keyword, count: places.length })
       allPlaces.push(...places)
@@ -396,8 +397,8 @@ export async function discoverAIResearch(campaign: Campaign): Promise<AIResearch
   )
 
   // Limit to top candidates for enrichment
-  // Each candidate gets website-scraped (up to 4 pages), so keep this modest to avoid timeouts
-  const MAX_ENRICHMENT_CANDIDATES = 50
+  // Each candidate gets website-scraped (up to 4 pages), so keep this reasonable
+  const MAX_ENRICHMENT_CANDIDATES = 100
   const topResults = sorted.slice(0, MAX_ENRICHMENT_CANDIDATES)
 
   console.log(`[AI Research] Top ${topResults.length} music organizations selected for enrichment`)
@@ -470,55 +471,78 @@ async function searchPlacesByKeyword(
   location: string,
   radius: number,
   keyword: string,
-  apiKey: string
+  apiKey: string,
+  diagnostics: AIResearchDiagnostics
 ): Promise<any[]> {
+  const allPlaces: any[] = []
   const query = `${keyword} in ${location}`
+
+  // First page
   const params = new URLSearchParams({
     query,
     location: `${lat},${lng}`,
-    radius: String(Math.min(radius, 50000)), // Legacy API max 50km
+    radius: String(radius),
     key: apiKey,
   })
 
-  const response = await fetch(
-    `https://maps.googleapis.com/maps/api/place/textsearch/json?${params}`
-  )
+  let pageUrl: string | null = `https://maps.googleapis.com/maps/api/place/textsearch/json?${params}`
+  let pageNum = 0
+  const MAX_PAGES = 3 // Google allows up to 3 pages (60 results total)
 
-  if (!response.ok) {
-    const errorBody = await response.text().catch(() => 'unknown')
-    console.error(`[AI Research] Places Text Search failed for "${query}":`, errorBody)
-    throw new Error(`Places API error: ${response.status} ${response.statusText}`)
-  }
+  while (pageUrl && pageNum < MAX_PAGES) {
+    if (pageNum > 0) {
+      diagnostics.apiCallsMade++ // Count pagination calls
+    }
 
-  const data = await response.json()
+    const response = await fetch(pageUrl)
 
-  if (data.status === 'REQUEST_DENIED') {
-    console.error(`[AI Research] Places API denied for "${query}": ${data.error_message || 'unknown'}`)
-    throw new Error(`Places API denied: ${data.error_message || 'Check API key and enabled APIs'}`)
-  }
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => 'unknown')
+      console.error(`[AI Research] Places Text Search failed for "${query}" page ${pageNum}:`, errorBody)
+      throw new Error(`Places API error: ${response.status} ${response.statusText}`)
+    }
 
-  if (data.status !== 'OK' && data.status !== 'ZERO_RESULTS') {
-    console.error(`[AI Research] Places API status "${data.status}" for "${query}": ${data.error_message || ''}`)
-    throw new Error(`Places API error: ${data.status}`)
-  }
+    const data = await response.json()
 
-  const places = data.results || []
+    if (data.status === 'REQUEST_DENIED') {
+      console.error(`[AI Research] Places API denied for "${query}": ${data.error_message || 'unknown'}`)
+      throw new Error(`Places API denied: ${data.error_message || 'Check API key and enabled APIs'}`)
+    }
 
-  console.log(`[AI Research] "${keyword}" → ${places.length} results`)
+    if (data.status !== 'OK' && data.status !== 'ZERO_RESULTS') {
+      console.error(`[AI Research] Places API status "${data.status}" for "${query}": ${data.error_message || ''}`)
+      throw new Error(`Places API error: ${data.status}`)
+    }
 
-  return places.map((place: any) => ({
-    name: place.name || '',
-    place_id: place.place_id,
-    geometry: {
-      location: {
-        lat: place.geometry?.location?.lat || 0,
-        lng: place.geometry?.location?.lng || 0,
+    const places = data.results || []
+    allPlaces.push(...places.map((place: any) => ({
+      name: place.name || '',
+      place_id: place.place_id,
+      geometry: {
+        location: {
+          lat: place.geometry?.location?.lat || 0,
+          lng: place.geometry?.location?.lng || 0,
+        },
       },
-    },
-    types: place.types || [],
-    formatted_address: place.formatted_address || '',
-    _searchKeyword: keyword,
-  }))
+      types: place.types || [],
+      formatted_address: place.formatted_address || '',
+      _searchKeyword: keyword,
+    })))
+
+    // Follow pagination if available
+    if (data.next_page_token) {
+      // Google requires a short delay before the next_page_token becomes valid
+      await new Promise(resolve => setTimeout(resolve, 2000))
+      pageUrl = `https://maps.googleapis.com/maps/api/place/textsearch/json?pagetoken=${data.next_page_token}&key=${apiKey}`
+      pageNum++
+    } else {
+      pageUrl = null
+    }
+  }
+
+  console.log(`[AI Research] "${keyword}" → ${allPlaces.length} results (${pageNum + 1} page${pageNum > 0 ? 's' : ''})`)
+
+  return allPlaces
 }
 
 /**

--- a/src/lib/discovery/orchestrator.ts
+++ b/src/lib/discovery/orchestrator.ts
@@ -11,6 +11,7 @@ import { discoverPastClients } from './past-clients'
 import { discoverDormantLeads } from './dormant-leads'
 import { discoverSimilarOrgs } from './similar-orgs'
 import { discoverAIResearch, type AIResearchDiagnostics } from './ai-research'
+import { discoverPerplexity, type PerplexityDiagnostics } from './perplexity'
 import { calculateScore, calculateScoreStats } from './scorer'
 import { deduplicate, getDeduplicationStats } from './deduplicator'
 import { classifyOrganization } from './org-classifier'
@@ -124,6 +125,11 @@ export async function discoverLeads(campaignId: string): Promise<DiscoveryResult
     warnings.push('GOOGLE_PLACES_API_KEY not configured — AI Research source will be skipped')
   }
 
+  // Check Perplexity API key
+  if (!process.env.PERPLEXITY_API_KEY) {
+    warnings.push('PERPLEXITY_API_KEY not configured — Perplexity AI discovery will be skipped')
+  }
+
   // Run all discovery sources in parallel, each wrapped in individual try/catch
   const sourceDiagnostics: SourceDiagnostic[] = []
   const sourceErrors: string[] = []
@@ -149,10 +155,11 @@ export async function discoverLeads(campaignId: string): Promise<DiscoveryResult
     }
   }
 
-  // AI Research needs special handling for its richer result type
+  // AI Research and Perplexity need special handling for their richer result types
   let aiResearchDiagnostics: AIResearchDiagnostics | undefined
+  let perplexityDiagnostics: PerplexityDiagnostics | undefined
 
-  const [pastClientsResult, dormantResult, similarResult, aiResearchResult] = await Promise.all([
+  const [pastClientsResult, dormantResult, similarResult, aiResearchResult, perplexityResult] = await Promise.all([
     runSource('Past Clients', () => discoverPastClients(campaign)),
     runSource('Dormant Leads', () => discoverDormantLeads(campaign)),
     runSource('Similar Orgs', () => discoverSimilarOrgs(campaign)),
@@ -163,6 +170,16 @@ export async function discoverLeads(campaignId: string): Promise<DiscoveryResult
       if (result.diagnostics.errors.length > 0) {
         for (const err of result.diagnostics.errors) {
           warnings.push(`AI Research: ${err}`)
+        }
+      }
+      return result.leads
+    }),
+    runSource('Perplexity AI', async () => {
+      const result = await discoverPerplexity(campaign)
+      perplexityDiagnostics = result.diagnostics
+      if (result.diagnostics.errors.length > 0) {
+        for (const err of result.diagnostics.errors) {
+          warnings.push(`Perplexity: ${err}`)
         }
       }
       return result.leads
@@ -181,24 +198,27 @@ export async function discoverLeads(campaignId: string): Promise<DiscoveryResult
   const dormant = dormantResult || []
   const similar = similarResult || []
   const aiResearch = aiResearchResult || []
+  const perplexity = perplexityResult || []
 
   console.log('[Discovery:Orchestrator] Source results', {
     pastClients: pastClients.length,
     dormant: dormant.length,
     similar: similar.length,
     aiResearch: aiResearch.length,
+    perplexity: perplexity.length,
   })
 
   // Track counts by source before deduplication
+  // Perplexity leads are tagged as AI_RESEARCH source, so combine the counts
   const bySource = {
     PAST_CLIENT: pastClients.length,
     DORMANT: dormant.length,
     SIMILAR_ORG: similar.length,
-    AI_RESEARCH: aiResearch.length,
+    AI_RESEARCH: aiResearch.length + perplexity.length,
   }
 
-  // Merge all leads
-  const allLeads = [...pastClients, ...dormant, ...similar, ...aiResearch]
+  // Merge all leads (Perplexity leads use AI_RESEARCH source for scoring consistency)
+  const allLeads = [...pastClients, ...dormant, ...similar, ...aiResearch, ...perplexity]
   const originalCount = allLeads.length
 
   // Deduplicate by email (keeping highest score per email)
@@ -253,11 +273,15 @@ export async function discoverLeads(campaignId: string): Promise<DiscoveryResult
     score: calculateScore(lead, campaign) + (lead.recommendationBonus || 0),
   }))
 
-  // Quality gate: reject low-score and unenriched leads
+  // Quality gate: reject low-score leads, but KEEP leads with website/phone even without email
   const qualityFiltered = scored.filter((lead) => {
-    // Reject placeholder emails — can't be used for outreach
-    if ((lead as any).email?.includes('@placeholder.local')) return false
-    if ((lead as any).needsEnrichment) return false
+    const hasPlaceholderEmail = (lead as any).email?.includes('@placeholder.local')
+    const needsEnrichment = (lead as any).needsEnrichment
+    const hasWebsite = !!(lead as any).website
+    const hasPhone = !!(lead as any).phone
+
+    // If no email AND no website AND no phone → truly useless, reject
+    if (hasPlaceholderEmail && !hasWebsite && !hasPhone) return false
 
     // Enforce minimum score by source
     const threshold = lead.source === 'AI_RESEARCH' ? COLD_SCORE_THRESHOLD : WARM_SCORE_THRESHOLD

--- a/src/lib/discovery/perplexity.ts
+++ b/src/lib/discovery/perplexity.ts
@@ -1,0 +1,299 @@
+/**
+ * Perplexity AI Discovery Source
+ *
+ * Uses Perplexity's Sonar API to find a cappella groups, choirs, and vocal ensembles
+ * that Google Places misses — community groups, university ensembles, church choirs
+ * without Google Business listings, etc.
+ *
+ * Perplexity aggregates results from across the web, finding organizations that
+ * only exist on Facebook, community websites, or university pages.
+ */
+
+import { prisma } from '@/lib/db'
+import { enrichOrganization } from '@/lib/enrichment'
+
+interface Campaign {
+  id: string
+  latitude: number
+  longitude: number
+  radius: number
+  baseLocation: string
+}
+
+interface PerplexityLead {
+  firstName: string
+  lastName: string
+  email: string
+  phone: string | null
+  organization: string
+  source: 'AI_RESEARCH'
+  latitude: number
+  longitude: number
+  score: number
+  distance: number
+  website?: string | null
+  emailVerified?: boolean
+  needsEnrichment?: boolean
+  enrichmentSource?: string | null
+  contactTitle?: string | null
+  editorialSummary?: string | null
+  googleRating?: number | null
+}
+
+export interface PerplexityDiagnostics {
+  apiCallsMade: number
+  apiCallsFailed: number
+  orgsFound: number
+  orgsEnriched: number
+  leadsCreated: number
+  errors: string[]
+}
+
+export interface PerplexityResult {
+  leads: PerplexityLead[]
+  diagnostics: PerplexityDiagnostics
+}
+
+interface ParsedOrg {
+  name: string
+  website?: string
+  phone?: string
+  description?: string
+}
+
+/**
+ * Query Perplexity Sonar API for vocal music organizations in a geographic area.
+ *
+ * Makes multiple targeted queries to maximize coverage:
+ * 1. A cappella groups
+ * 2. Choirs and choruses
+ * 3. Barbershop harmony (not haircut shops)
+ * 4. Youth/school vocal programs
+ */
+export async function discoverPerplexity(campaign: Campaign): Promise<PerplexityResult> {
+  const apiKey = process.env.PERPLEXITY_API_KEY
+
+  const diagnostics: PerplexityDiagnostics = {
+    apiCallsMade: 0,
+    apiCallsFailed: 0,
+    orgsFound: 0,
+    orgsEnriched: 0,
+    leadsCreated: 0,
+    errors: [],
+  }
+
+  if (!apiKey) {
+    console.log('[Perplexity] PERPLEXITY_API_KEY not set — skipping Perplexity discovery')
+    return { leads: [], diagnostics }
+  }
+
+  const location = campaign.baseLocation
+  const radius = campaign.radius
+
+  // Targeted queries that maximize coverage of different organization types
+  const queries = [
+    `List every a cappella group, a cappella ensemble, and a cappella club within ${radius} miles of ${location}. Include university, college, high school, community, and professional groups. For each group provide the name, website URL if available, and phone number if available. Be exhaustive — include small community groups too.`,
+    `List every choir, chorus, chorale, and vocal ensemble within ${radius} miles of ${location}. Include church choirs, community choruses, professional choirs, and youth choirs. For each provide the name, website URL if available, and phone number if available. Be as comprehensive as possible.`,
+    `List every barbershop harmony group, Sweet Adelines chapter, Harmony Inc chapter, and BHS chorus within ${radius} miles of ${location}. For each provide the name, website URL if available, and phone number if available.`,
+    `List every music school, conservatory, vocal music program, and singing group within ${radius} miles of ${location} that is not already a standard choir or a cappella group. Include community music schools, private vocal studios that run group programs, and festival choruses. For each provide the name, website URL, and phone number if available.`,
+  ]
+
+  const allOrgs: ParsedOrg[] = []
+
+  for (const query of queries) {
+    diagnostics.apiCallsMade++
+    try {
+      const orgs = await queryPerplexity(query, apiKey)
+      allOrgs.push(...orgs)
+      console.log(`[Perplexity] Query returned ${orgs.length} organizations`)
+    } catch (error) {
+      diagnostics.apiCallsFailed++
+      const errMsg = error instanceof Error ? error.message : String(error)
+      diagnostics.errors.push(errMsg)
+      console.error(`[Perplexity] Query failed:`, errMsg)
+    }
+  }
+
+  // Deduplicate by name
+  const seen = new Map<string, ParsedOrg>()
+  for (const org of allOrgs) {
+    const key = org.name.toLowerCase().replace(/[^a-z0-9]/g, '')
+    if (!seen.has(key)) {
+      seen.set(key, org)
+    } else {
+      // Merge: prefer the entry with more data
+      const existing = seen.get(key)!
+      if (!existing.website && org.website) existing.website = org.website
+      if (!existing.phone && org.phone) existing.phone = org.phone
+      if (!existing.description && org.description) existing.description = org.description
+    }
+  }
+
+  const uniqueOrgs = Array.from(seen.values())
+  diagnostics.orgsFound = uniqueOrgs.length
+  console.log(`[Perplexity] ${uniqueOrgs.length} unique organizations after dedup (from ${allOrgs.length} raw)`)
+
+  // Check which organizations already exist in the database
+  const existingLeads = await prisma.lead.findMany({
+    where: {
+      organization: {
+        in: uniqueOrgs.map(o => o.name),
+      },
+    },
+    select: {
+      organization: true,
+      email: true,
+    },
+  })
+  const existingOrgSet = new Set(existingLeads.map(l => l.organization?.toLowerCase()))
+
+  // Enrich new organizations
+  const leads: PerplexityLead[] = []
+
+  for (const org of uniqueOrgs) {
+    // Skip if already in database
+    if (existingOrgSet.has(org.name.toLowerCase())) {
+      continue
+    }
+
+    const enrichment = await enrichOrganization(
+      org.website || null,
+      org.phone || null,
+      org.name
+    )
+    diagnostics.orgsEnriched++
+
+    // Use campaign center as coordinates (Perplexity doesn't give lat/lng)
+    // These will be refined later if we can geocode the org's address
+    const lat = campaign.latitude
+    const lng = campaign.longitude
+
+    if (enrichment.email) {
+      leads.push({
+        firstName: enrichment.firstName || 'Contact',
+        lastName: enrichment.lastName || `at ${org.name}`,
+        email: enrichment.email,
+        phone: enrichment.phone || org.phone || null,
+        organization: org.name,
+        source: 'AI_RESEARCH',
+        latitude: lat,
+        longitude: lng,
+        score: 30,
+        distance: 0, // Within the search area by definition
+        website: enrichment.website || org.website || null,
+        emailVerified: enrichment.emailVerified,
+        needsEnrichment: false,
+        enrichmentSource: enrichment.enrichmentSource,
+        contactTitle: enrichment.contactTitle || null,
+        editorialSummary: org.description || null,
+      })
+    } else {
+      // No email found — still create lead with website/phone for preview
+      const placeholderEmail = `needs-enrichment+${org.name.toLowerCase().replace(/[^a-z0-9]/g, '-').substring(0, 40)}@placeholder.local`
+
+      leads.push({
+        firstName: 'Contact',
+        lastName: `at ${org.name}`,
+        email: placeholderEmail,
+        phone: enrichment.phone || org.phone || null,
+        organization: org.name,
+        source: 'AI_RESEARCH',
+        latitude: lat,
+        longitude: lng,
+        score: 20,
+        distance: 0,
+        website: enrichment.website || org.website || null,
+        emailVerified: false,
+        needsEnrichment: true,
+        enrichmentSource: null,
+        contactTitle: enrichment.contactTitle || null,
+        editorialSummary: org.description || null,
+      })
+    }
+  }
+
+  diagnostics.leadsCreated = leads.length
+  console.log(`[Perplexity] SUMMARY: ${diagnostics.apiCallsMade} calls, ${diagnostics.orgsFound} orgs found, ${diagnostics.orgsEnriched} enriched, ${diagnostics.leadsCreated} leads created`)
+
+  return { leads, diagnostics }
+}
+
+/**
+ * Query Perplexity Sonar API and parse the response into organizations
+ */
+async function queryPerplexity(query: string, apiKey: string): Promise<ParsedOrg[]> {
+  const response = await fetch('https://api.perplexity.ai/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: 'sonar',
+      messages: [
+        {
+          role: 'system',
+          content: `You are a research assistant. Return ONLY a JSON array of organizations. Each object must have: "name" (string, required), "website" (string or null), "phone" (string or null), "description" (string or null, one sentence about the group). Do not include any text outside the JSON array. Do not include markdown formatting. If you find no results, return an empty array [].`
+        },
+        {
+          role: 'user',
+          content: query,
+        },
+      ],
+      temperature: 0.1,
+      max_tokens: 4000,
+    }),
+  })
+
+  if (!response.ok) {
+    const errorBody = await response.text().catch(() => 'unknown')
+    throw new Error(`Perplexity API error ${response.status}: ${errorBody}`)
+  }
+
+  const data = await response.json()
+  const content = data.choices?.[0]?.message?.content || ''
+
+  return parseOrgsFromResponse(content)
+}
+
+/**
+ * Parse organizations from Perplexity's response text.
+ * Handles both clean JSON and markdown-wrapped JSON.
+ */
+function parseOrgsFromResponse(content: string): ParsedOrg[] {
+  // Try to extract JSON array from the response
+  let jsonStr = content.trim()
+
+  // Strip markdown code fences if present
+  const jsonMatch = jsonStr.match(/```(?:json)?\s*([\s\S]*?)```/)
+  if (jsonMatch) {
+    jsonStr = jsonMatch[1].trim()
+  }
+
+  // Find the first [ and last ]
+  const start = jsonStr.indexOf('[')
+  const end = jsonStr.lastIndexOf(']')
+  if (start === -1 || end === -1) {
+    console.warn('[Perplexity] No JSON array found in response')
+    return []
+  }
+
+  jsonStr = jsonStr.substring(start, end + 1)
+
+  try {
+    const parsed = JSON.parse(jsonStr)
+    if (!Array.isArray(parsed)) return []
+
+    return parsed
+      .filter((item: any) => item && typeof item.name === 'string' && item.name.trim())
+      .map((item: any) => ({
+        name: item.name.trim(),
+        website: typeof item.website === 'string' ? item.website.trim() : undefined,
+        phone: typeof item.phone === 'string' ? item.phone.trim() : undefined,
+        description: typeof item.description === 'string' ? item.description.trim() : undefined,
+      }))
+  } catch (error) {
+    console.warn('[Perplexity] Failed to parse JSON from response:', error)
+    return []
+  }
+}


### PR DESCRIPTION
…gate fix

Three major fixes to go from ~13 leads to 50-100+:

1. Google Places pagination: follow next_page_token for up to 60 results per keyword (was capped at 20). Also removed the 50km radius cap that silently reduced a 50-mile search to 31 miles.

2. Perplexity AI as additional discovery source: uses Sonar API to find choirs, a cappella groups, and vocal ensembles that Google Places misses (community groups, university ensembles, Facebook-only groups, etc.). Gracefully skips if PERPLEXITY_API_KEY not set.

3. Quality gate: stop discarding leads that have website/phone but no email. These are still valuable — user can see them in the preview panel and reach out manually.

Also bumped enrichment candidate limit from 50 to 100.

https://claude.ai/code/session_01528mTZYT7x16ak3fXiV8fa