### PR TITLE
Refactor discovery to async background job with polling

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@types/pg": "^8.16.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "dotenv": "^17.2.3",
+    "dotenv": "^17.3.1",
     "eslint": "^9",
     "eslint-config-next": "16.1.1",
     "tailwindcss": "^4",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -478,6 +478,11 @@ model Campaign {
   outreachLogs  OutreachLog[]
   emailDrafts   EmailDraft[]
 
+  // Background discovery job tracking
+  discoveryStatus    String?      // null, "RUNNING", "COMPLETED", "FAILED"
+  discoveryStartedAt DateTime?
+  discoveryError     String?
+
   // Prospect mode: target org types without requiring a booking
   targetOrgTypes  String?      // JSON array: ["CHOIR", "BARBERSHOP", "MUSIC_SCHOOL"]
 

--- a/src/app/api/campaigns/[id]/discover/route.ts
+++ b/src/app/api/campaigns/[id]/discover/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { handleApiError, ApiError } from '@/lib/api-error'
-import { discoverLeads } from '@/lib/discovery'
-import { renderTemplate } from '@/lib/outreach/template-renderer'
+import { runDiscoveryInBackground } from '@/lib/discovery/background-runner'
 
 type Params = {
   params: Promise<{
@@ -10,39 +9,106 @@ type Params = {
   }>
 }
 
+// Stale job timeout: 10 minutes
+const STALE_JOB_TIMEOUT_MS = 10 * 60 * 1000
+
 /**
  * POST /api/campaigns/[id]/discover
  *
- * Streamlined 3-step workflow: Create -> [auto: discover + enrich + draft] -> Review & Send
- *
- * 1. Runs all discovery sources (past clients, dormant, similar orgs, AI research)
- * 2. AI Research now enriches via website scraping (real contacts, not fake)
- * 3. Auto-generates email drafts for leads with verified/scraped emails
- * 4. Sets campaign status to READY
+ * Starts discovery as a background job. Returns 202 Accepted immediately.
+ * Poll GET /api/campaigns/[id]/discover for status.
  */
 export async function POST(request: NextRequest, { params }: Params) {
   try {
     const { id } = await params
 
-    // Verify campaign exists (include booking for date context)
     const campaign = await prisma.campaign.findUnique({
       where: { id },
       select: {
         id: true,
         name: true,
-        baseLocation: true,
-        latitude: true,
-        longitude: true,
-        radius: true,
+        discoveryStatus: true,
+        discoveryStartedAt: true,
+      },
+    })
+
+    if (!campaign) {
+      throw new ApiError(404, 'Campaign not found', 'CAMPAIGN_NOT_FOUND')
+    }
+
+    // Check if discovery is already running
+    if (campaign.discoveryStatus === 'RUNNING') {
+      // Check for stale job
+      const startedAt = campaign.discoveryStartedAt?.getTime() || 0
+      const isStale = Date.now() - startedAt > STALE_JOB_TIMEOUT_MS
+
+      if (!isStale) {
+        return NextResponse.json(
+          { message: 'Discovery is already running', status: 'running' },
+          { status: 409 }
+        )
+      }
+
+      // Stale job — mark it failed and allow restart
+      console.warn(`[Discover] Stale discovery job detected for campaign ${id}, allowing restart`)
+      await prisma.campaign.update({
+        where: { id },
+        data: {
+          discoveryStatus: 'FAILED',
+          discoveryError: 'Discovery timed out (server may have restarted)',
+        },
+      })
+    }
+
+    // Mark as running
+    await prisma.campaign.update({
+      where: { id },
+      data: {
+        discoveryStatus: 'RUNNING',
+        discoveryStartedAt: new Date(),
+        discoveryError: null,
+      },
+    })
+
+    // Fire and forget — do NOT await
+    runDiscoveryInBackground(id)
+
+    return NextResponse.json(
+      {
+        message: 'Discovery started',
+        status: 'started',
+        campaignId: id,
+        campaignName: campaign.name,
+      },
+      { status: 202 }
+    )
+  } catch (error) {
+    return handleApiError(error)
+  }
+}
+
+/**
+ * GET /api/campaigns/[id]/discover
+ *
+ * Returns current discovery status. Frontend polls this every few seconds.
+ */
+export async function GET(request: NextRequest, { params }: Params) {
+  try {
+    const { id } = await params
+
+    const campaign = await prisma.campaign.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        name: true,
         status: true,
-        startDate: true,
-        endDate: true,
-        booking: {
+        discoveryStatus: true,
+        discoveryStartedAt: true,
+        discoveryError: true,
+        _count: {
           select: {
-            startDate: true,
-            endDate: true,
-            serviceType: true,
-            location: true,
+            leads: true,
+            emailDrafts: true,
           },
         },
       },
@@ -52,180 +118,82 @@ export async function POST(request: NextRequest, { params }: Params) {
       throw new ApiError(404, 'Campaign not found', 'CAMPAIGN_NOT_FOUND')
     }
 
-    // Run discovery engine (includes enrichment)
-    const result = await discoverLeads(id)
+    // Check for stale running job
+    if (campaign.discoveryStatus === 'RUNNING') {
+      const startedAt = campaign.discoveryStartedAt?.getTime() || 0
+      const isStale = Date.now() - startedAt > STALE_JOB_TIMEOUT_MS
 
-    // Auto-generate email drafts for leads with real emails
-    let draftsGenerated = 0
-    let draftsSkipped = 0
-
-    try {
-      // Build availability date string from campaign or booking dates
-      const formatDate = (d: Date | string | null) => {
-        if (!d) return null
-        return new Date(d).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
-      }
-
-      const availStart = formatDate(campaign.booking?.startDate || campaign.startDate)
-      const availEnd = formatDate(campaign.booking?.endDate || campaign.endDate)
-      let availabilityDates = ''
-      if (availStart && availEnd) {
-        availabilityDates = `${availStart} through ${availEnd}`
-      } else if (availStart) {
-        availabilityDates = `around ${availStart}`
-      }
-
-      const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://dekesharon.com'
-      const workshopLink = `${baseUrl}/workshops`
-      const servicesLink = `${baseUrl}/services`
-
-      // Find template
-      let templateSubject = 'Collaboration Opportunity with Deke Sharon'
-      let templateBody = `Hi {{firstName}},
-
-I'm Deke Sharon, and I'll be in the {{baseLocation}} area{{availabilityDates}} — I'd love to explore working with {{organization}}.
-
-I offer workshops, coaching, and masterclasses tailored to vocal groups of all levels. You can see the full list of what I offer here: {{workshopLink}}
-
-Would you be open to a quick conversation about what might be a good fit?
-
-Best,
-Deke Sharon
-{{servicesLink}}`
-
-      const defaultTemplate = await prisma.messageTemplate.findFirst({
-        where: { channel: 'EMAIL' },
-        orderBy: { createdAt: 'desc' },
-      })
-      if (defaultTemplate) {
-        templateSubject = defaultTemplate.subject || templateSubject
-        templateBody = defaultTemplate.body
-      }
-
-      // Get campaign leads that have real emails (not placeholder or needsEnrichment)
-      const campaignLeads = await prisma.campaignLead.findMany({
-        where: {
-          campaignId: id,
-        },
-        include: {
-          lead: true,
-        },
-      })
-
-      // Check which already have drafts
-      const existingDrafts = await prisma.emailDraft.findMany({
-        where: { campaignId: id },
-        select: { campaignLeadId: true },
-      })
-      const existingDraftIds = new Set(existingDrafts.map(d => d.campaignLeadId))
-
-      for (const cl of campaignLeads) {
-        // Skip if already has a draft
-        if (existingDraftIds.has(cl.id)) {
-          draftsSkipped++
-          continue
-        }
-
-        // Skip leads that need enrichment (no usable email)
-        if (cl.lead.needsEnrichment || cl.lead.email.includes('@placeholder.local')) {
-          draftsSkipped++
-          continue
-        }
-
-        const vars: Record<string, string> = {
-          firstName: cl.lead.firstName,
-          lastName: cl.lead.lastName,
-          organization: cl.lead.organization || '',
-          contactTitle: cl.lead.contactTitle || '',
-          editorialSummary: cl.lead.editorialSummary || '',
-          email: cl.lead.email,
-          baseLocation: campaign.baseLocation,
-          availabilityDates: availabilityDates ? ` ${availabilityDates}` : ' soon',
-          workshopLink,
-          servicesLink,
-        }
-
-        const renderedSubject = renderTemplate(templateSubject, vars)
-        const renderedBody = renderTemplate(templateBody, vars)
-
-        await prisma.emailDraft.create({
+      if (isStale) {
+        await prisma.campaign.update({
+          where: { id },
           data: {
-            campaignId: id,
-            campaignLeadId: cl.id,
-            leadId: cl.leadId,
-            subject: renderedSubject,
-            body: renderedBody,
-            status: 'DRAFT',
+            discoveryStatus: 'FAILED',
+            discoveryError: 'Discovery timed out (server may have restarted)',
           },
         })
-        draftsGenerated++
+
+        return NextResponse.json({
+          status: 'failed',
+          error: 'Discovery timed out (server may have restarted). Try again.',
+          campaignId: id,
+        })
       }
 
-      console.log(`[Discover] Auto-generated ${draftsGenerated} drafts, skipped ${draftsSkipped}`)
-    } catch (draftError) {
-      console.error('[Discover] Draft generation failed (discovery still succeeded):', draftError)
-    }
-
-    // Auto-advance campaign status to READY
-    if (campaign.status === 'DRAFT') {
-      await prisma.campaign.update({
-        where: { id },
-        data: { status: 'READY' },
+      const elapsedMs = Date.now() - startedAt
+      return NextResponse.json({
+        status: 'running',
+        campaignId: id,
+        startedAt: campaign.discoveryStartedAt,
+        elapsedMs,
       })
     }
 
-    const status = result.total === 0 ? 'no_results' : 'success'
+    if (campaign.discoveryStatus === 'COMPLETED') {
+      // Get source breakdown
+      const sourceBreakdown = await prisma.campaignLead.groupBy({
+        by: ['source'],
+        where: { campaignId: id },
+        _count: true,
+      })
 
-    return NextResponse.json(
-      {
-        message: result.total === 0
-          ? 'Discovery completed but found no leads — check diagnostics for details'
-          : 'Lead discovery and draft generation completed',
-        status,
-        campaignId: campaign.id,
+      const bySource: Record<string, number> = {}
+      for (const s of sourceBreakdown) {
+        bySource[s.source] = s._count
+      }
+
+      // Get draft counts
+      const draftCount = await prisma.emailDraft.count({
+        where: { campaignId: id },
+      })
+
+      return NextResponse.json({
+        status: 'completed',
+        campaignId: id,
         campaignName: campaign.name,
         discovered: {
-          total: result.total,
-          bySource: {
-            pastClients: result.bySource.PAST_CLIENT,
-            dormantLeads: result.bySource.DORMANT,
-            similarOrgs: result.bySource.SIMILAR_ORG,
-            aiResearch: result.bySource.AI_RESEARCH,
-          },
+          total: campaign._count.leads,
+          bySource,
         },
         drafts: {
-          generated: draftsGenerated,
-          skipped: draftsSkipped,
+          generated: draftCount,
         },
-        scoring: {
-          avgScore: result.avgScore,
-          scoreDistribution: result.scoreStats.distribution,
-          min: result.scoreStats.min,
-          max: result.scoreStats.max,
-          median: result.scoreStats.median,
-        },
-        deduplication: {
-          originalCount: result.deduplicationStats.original,
-          duplicatesRemoved: result.deduplicationStats.duplicatesRemoved,
-          deduplicationRate: result.deduplicationStats.deduplicationRate,
-        },
-        performance: {
-          duration: result.duration,
-          leadsPerSecond: result.duration > 0 ? Math.round((result.total / result.duration) * 1000) : 0,
-        },
-        warnings: result.warnings || [],
-        errors: result.errors || [],
-        diagnostics: (result.diagnostics || []).map(d => ({
-          source: d.source,
-          count: d.count,
-          durationMs: d.durationMs,
-          error: d.error || null,
-          details: d.details || null,
-        })),
-        newLeadsCount: result.total,
-      },
-      { status: 200 }
-    )
+      })
+    }
+
+    if (campaign.discoveryStatus === 'FAILED') {
+      return NextResponse.json({
+        status: 'failed',
+        campaignId: id,
+        error: campaign.discoveryError || 'Discovery failed (unknown error)',
+      })
+    }
+
+    // No discovery has been run yet
+    return NextResponse.json({
+      status: 'idle',
+      campaignId: id,
+      leadsCount: campaign._count.leads,
+    })
   } catch (error) {
     return handleApiError(error)
   }

--- a/src/app/dashboard/campaigns/[id]/page.tsx
+++ b/src/app/dashboard/campaigns/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useEffect, useState } from "react";
+import { use, useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -184,37 +184,99 @@ export default function CampaignDetailPage({
 
   const [isDiscovering, setIsDiscovering] = useState(false);
   const [discoveryResult, setDiscoveryResult] = useState<any>(null);
+  const [discoveryElapsed, setDiscoveryElapsed] = useState(0);
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopPolling = useCallback(() => {
+    if (pollIntervalRef.current) {
+      clearInterval(pollIntervalRef.current);
+      pollIntervalRef.current = null;
+    }
+  }, []);
+
+  const pollDiscoveryStatus = useCallback(async () => {
+    try {
+      const response = await fetch(`/api/campaigns/${id}/discover`);
+      if (!response.ok) return;
+
+      const data = await response.json();
+
+      if (data.status === "running") {
+        setDiscoveryElapsed(data.elapsedMs || 0);
+      } else if (data.status === "completed") {
+        stopPolling();
+        setIsDiscovering(false);
+        setDiscoveryResult(data);
+        await fetchCampaign();
+      } else if (data.status === "failed") {
+        stopPolling();
+        setIsDiscovering(false);
+        setDiscoveryResult({ error: data.error || "Discovery failed" });
+      }
+    } catch {
+      // Network error during poll — keep trying
+    }
+  }, [id, stopPolling]);
+
+  // Start polling for discovery status
+  const startPolling = useCallback(() => {
+    stopPolling();
+    setIsDiscovering(true);
+    setDiscoveryElapsed(0);
+    pollIntervalRef.current = setInterval(pollDiscoveryStatus, 3000);
+  }, [stopPolling, pollDiscoveryStatus]);
+
+  // Clean up polling on unmount
+  useEffect(() => {
+    return () => stopPolling();
+  }, [stopPolling]);
+
+  // Auto-resume polling if discovery is already running when page loads
+  useEffect(() => {
+    if (!campaign) return;
+
+    const checkRunning = async () => {
+      try {
+        const response = await fetch(`/api/campaigns/${id}/discover`);
+        if (!response.ok) return;
+        const data = await response.json();
+        if (data.status === "running") {
+          startPolling();
+        }
+      } catch {
+        // Ignore
+      }
+    };
+    checkRunning();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [campaign?.id]);
 
   const handleDiscoverLeads = async () => {
     if (!campaign) return;
 
     try {
-      setIsDiscovering(true);
       setDiscoveryResult(null);
       const response = await fetch(`/api/campaigns/${campaign.id}/discover`, {
         method: "POST",
         headers: { "Content-Type": "application/json" }
       });
 
+      if (response.status === 409) {
+        // Already running — just start polling
+        startPolling();
+        return;
+      }
+
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.message || "Failed to discover leads");
+        throw new Error(errorData.message || "Failed to start discovery");
       }
 
-      const result = await response.json();
-      setDiscoveryResult(result);
-
-      if (result.discovered?.total === 0) {
-        // Don't use alert — the UI will show diagnostics inline
-        console.warn("Discovery returned 0 leads. Diagnostics:", result.diagnostics);
-      }
-
-      await fetchCampaign();
+      // Started successfully — begin polling
+      startPolling();
     } catch (err) {
-      console.error("Error discovering leads:", err);
-      setDiscoveryResult({ error: err instanceof Error ? err.message : "Failed to discover leads" });
-    } finally {
-      setIsDiscovering(false);
+      console.error("Error starting discovery:", err);
+      setDiscoveryResult({ error: err instanceof Error ? err.message : "Failed to start discovery" });
     }
   };
 
@@ -352,13 +414,15 @@ export default function CampaignDetailPage({
             <div className="flex flex-col gap-2">
               <Button onClick={handleDiscoverLeads} disabled={isDiscovering}>
                 {isDiscovering ? (
-                  <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Discovering...</>
+                  <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Discovering... {discoveryElapsed > 0 ? `${Math.round(discoveryElapsed / 1000)}s` : ''}</>
                 ) : (
                   <><Target className="h-4 w-4 mr-2" />Discover & Draft</>
                 )}
               </Button>
               <p className="text-sm text-muted-foreground">
-                Find leads, enrich contacts, and generate email drafts
+                {isDiscovering
+                  ? "Running in background — safe to navigate away"
+                  : "Find leads, enrich contacts, and generate email drafts"}
               </p>
             </div>
           )}
@@ -666,7 +730,7 @@ export default function CampaignDetailPage({
               disabled={!campaign || isDiscovering}
             >
               {isDiscovering ? (
-                <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Discovering...</>
+                <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Discovering... {discoveryElapsed > 0 ? `${Math.round(discoveryElapsed / 1000)}s` : ''}</>
               ) : (
                 <><Target className="h-4 w-4 mr-2" />Discover More Leads</>
               )}
@@ -712,7 +776,7 @@ export default function CampaignDetailPage({
                     variant="outline"
                   >
                     {isDiscovering ? (
-                      <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Discovering...</>
+                      <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Discovering... {discoveryElapsed > 0 ? `${Math.round(discoveryElapsed / 1000)}s` : ''}</>
                     ) : (
                       <><Target className="h-4 w-4 mr-2" />{discoveryResult ? 'Re-run Discovery' : 'Run Discovery'}</>
                     )}

--- a/src/lib/discovery/ai-research.ts
+++ b/src/lib/discovery/ai-research.ts
@@ -62,21 +62,14 @@ const MUSIC_KEYWORDS = [
   'chorus',
   'chorale',
   'Sweet Adelines',
-  'Harmony Inc',
   'Barbershop Harmony Society',
-  'BHS chorus',
-  'CASA a cappella',
   'a cappella group',
   'vocal ensemble',
-  'gospel choir',
   'community chorus',
 
   // Youth music education
   'high school choir',
-  'middle school choir',
   'music school',
-  'conservatory',
-  'youth choir',
 ]
 
 /**
@@ -398,7 +391,7 @@ export async function discoverAIResearch(campaign: Campaign): Promise<AIResearch
 
   // Limit to top candidates for enrichment
   // Each candidate gets website-scraped (up to 4 pages), so keep this reasonable
-  const MAX_ENRICHMENT_CANDIDATES = 100
+  const MAX_ENRICHMENT_CANDIDATES = 50
   const topResults = sorted.slice(0, MAX_ENRICHMENT_CANDIDATES)
 
   console.log(`[AI Research] Top ${topResults.length} music organizations selected for enrichment`)
@@ -487,7 +480,7 @@ async function searchPlacesByKeyword(
 
   let pageUrl: string | null = `https://maps.googleapis.com/maps/api/place/textsearch/json?${params}`
   let pageNum = 0
-  const MAX_PAGES = 3 // Google allows up to 3 pages (60 results total)
+  const MAX_PAGES = 2 // Limit to 2 pages (40 results) to reduce processing time
 
   while (pageUrl && pageNum < MAX_PAGES) {
     if (pageNum > 0) {

--- a/src/lib/discovery/background-runner.ts
+++ b/src/lib/discovery/background-runner.ts
@@ -1,0 +1,67 @@
+/**
+ * Background Discovery Runner
+ *
+ * Runs the discovery pipeline as a background job (detached promise).
+ * Updates campaign.discoveryStatus so the frontend can poll for progress.
+ */
+
+import { prisma } from '@/lib/db'
+import { discoverLeads } from './orchestrator'
+import { generateDraftsForCampaign } from './draft-generator'
+
+/**
+ * Run discovery in the background (fire-and-forget).
+ *
+ * Call this WITHOUT await — it runs as a detached promise in the Node.js event loop.
+ * Updates discoveryStatus in the database so the frontend can poll GET /api/campaigns/[id]/discover.
+ *
+ * @param campaignId - The campaign to run discovery for
+ */
+export function runDiscoveryInBackground(campaignId: string): void {
+  // Detached promise — intentionally not awaited
+  void (async () => {
+    try {
+      console.log(`[BackgroundRunner] Starting discovery for campaign ${campaignId}`)
+
+      // Run the discovery orchestrator
+      const result = await discoverLeads(campaignId)
+
+      // Generate email drafts
+      let drafts = { generated: 0, skipped: 0 }
+      try {
+        drafts = await generateDraftsForCampaign(campaignId)
+      } catch (draftError) {
+        console.error('[BackgroundRunner] Draft generation failed (discovery still succeeded):', draftError)
+      }
+
+      // Mark as completed and advance campaign status
+      await prisma.campaign.update({
+        where: { id: campaignId },
+        data: {
+          discoveryStatus: 'COMPLETED',
+          discoveryError: null,
+          // Auto-advance from DRAFT to READY
+          ...(await prisma.campaign.findUnique({ where: { id: campaignId }, select: { status: true } })
+            .then(c => c?.status === 'DRAFT' ? { status: 'READY' } : {})),
+        },
+      })
+
+      console.log(`[BackgroundRunner] Discovery completed for campaign ${campaignId}: ${result.total} leads, ${drafts.generated} drafts`)
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      console.error(`[BackgroundRunner] Discovery FAILED for campaign ${campaignId}:`, errorMessage)
+
+      try {
+        await prisma.campaign.update({
+          where: { id: campaignId },
+          data: {
+            discoveryStatus: 'FAILED',
+            discoveryError: errorMessage.substring(0, 1000), // Truncate for DB storage
+          },
+        })
+      } catch (dbError) {
+        console.error('[BackgroundRunner] Failed to update campaign status after error:', dbError)
+      }
+    }
+  })()
+}

--- a/src/lib/discovery/draft-generator.ts
+++ b/src/lib/discovery/draft-generator.ts
@@ -1,0 +1,145 @@
+/**
+ * Draft Generator
+ *
+ * Generates email drafts for campaign leads after discovery.
+ * Extracted from the discover route for reuse by the background runner.
+ */
+
+import { prisma } from '@/lib/db'
+import { renderTemplate } from '@/lib/outreach/template-renderer'
+
+export interface DraftGenerationResult {
+  generated: number
+  skipped: number
+}
+
+/**
+ * Generate email drafts for all leads in a campaign that have usable emails.
+ *
+ * @param campaignId - The campaign to generate drafts for
+ * @returns Count of drafts generated and skipped
+ */
+export async function generateDraftsForCampaign(campaignId: string): Promise<DraftGenerationResult> {
+  let draftsGenerated = 0
+  let draftsSkipped = 0
+
+  const campaign = await prisma.campaign.findUnique({
+    where: { id: campaignId },
+    select: {
+      id: true,
+      baseLocation: true,
+      startDate: true,
+      endDate: true,
+      booking: {
+        select: {
+          startDate: true,
+          endDate: true,
+        },
+      },
+    },
+  })
+
+  if (!campaign) {
+    throw new Error('Campaign not found')
+  }
+
+  // Build availability date string from campaign or booking dates
+  const formatDate = (d: Date | string | null) => {
+    if (!d) return null
+    return new Date(d).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+  }
+
+  const availStart = formatDate(campaign.booking?.startDate || campaign.startDate)
+  const availEnd = formatDate(campaign.booking?.endDate || campaign.endDate)
+  let availabilityDates = ''
+  if (availStart && availEnd) {
+    availabilityDates = `${availStart} through ${availEnd}`
+  } else if (availStart) {
+    availabilityDates = `around ${availStart}`
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://dekesharon.com'
+  const workshopLink = `${baseUrl}/workshops`
+  const servicesLink = `${baseUrl}/services`
+
+  // Find template
+  let templateSubject = 'Collaboration Opportunity with Deke Sharon'
+  let templateBody = `Hi {{firstName}},
+
+I'm Deke Sharon, and I'll be in the {{baseLocation}} area{{availabilityDates}} — I'd love to explore working with {{organization}}.
+
+I offer workshops, coaching, and masterclasses tailored to vocal groups of all levels. You can see the full list of what I offer here: {{workshopLink}}
+
+Would you be open to a quick conversation about what might be a good fit?
+
+Best,
+Deke Sharon
+{{servicesLink}}`
+
+  const defaultTemplate = await prisma.messageTemplate.findFirst({
+    where: { channel: 'EMAIL' },
+    orderBy: { createdAt: 'desc' },
+  })
+  if (defaultTemplate) {
+    templateSubject = defaultTemplate.subject || templateSubject
+    templateBody = defaultTemplate.body
+  }
+
+  // Get campaign leads that have real emails
+  const campaignLeads = await prisma.campaignLead.findMany({
+    where: { campaignId },
+    include: { lead: true },
+  })
+
+  // Check which already have drafts
+  const existingDrafts = await prisma.emailDraft.findMany({
+    where: { campaignId },
+    select: { campaignLeadId: true },
+  })
+  const existingDraftIds = new Set(existingDrafts.map(d => d.campaignLeadId))
+
+  for (const cl of campaignLeads) {
+    // Skip if already has a draft
+    if (existingDraftIds.has(cl.id)) {
+      draftsSkipped++
+      continue
+    }
+
+    // Skip leads that need enrichment (no usable email)
+    if (cl.lead.needsEnrichment || cl.lead.email.includes('@placeholder.local')) {
+      draftsSkipped++
+      continue
+    }
+
+    const vars: Record<string, string> = {
+      firstName: cl.lead.firstName,
+      lastName: cl.lead.lastName,
+      organization: cl.lead.organization || '',
+      contactTitle: cl.lead.contactTitle || '',
+      editorialSummary: cl.lead.editorialSummary || '',
+      email: cl.lead.email,
+      baseLocation: campaign.baseLocation,
+      availabilityDates: availabilityDates ? ` ${availabilityDates}` : ' soon',
+      workshopLink,
+      servicesLink,
+    }
+
+    const renderedSubject = renderTemplate(templateSubject, vars)
+    const renderedBody = renderTemplate(templateBody, vars)
+
+    await prisma.emailDraft.create({
+      data: {
+        campaignId,
+        campaignLeadId: cl.id,
+        leadId: cl.leadId,
+        subject: renderedSubject,
+        body: renderedBody,
+        status: 'DRAFT',
+      },
+    })
+    draftsGenerated++
+  }
+
+  console.log(`[DraftGenerator] Generated ${draftsGenerated} drafts, skipped ${draftsSkipped}`)
+  return { generated: draftsGenerated, skipped: draftsSkipped }
+}


### PR DESCRIPTION
## Summary
Converts the synchronous lead discovery process into an asynchronous background job model. The POST endpoint now returns immediately (202 Accepted) while discovery runs in the background, and a new GET endpoint allows the frontend to poll for status updates.

## Key Changes

- **Async discovery architecture**: POST `/api/campaigns/[id]/discover` now starts discovery as a fire-and-forget background job and returns immediately with 202 status, instead of blocking until completion
- **Status polling**: New GET `/api/campaigns/[id]/discover` endpoint returns current discovery status (idle, running, completed, failed) with elapsed time and result counts
- **Stale job detection**: Implements 10-minute timeout to detect and recover from stale discovery jobs (e.g., after server restart)
- **Draft generation extraction**: Moved email draft generation logic into new `draft-generator.ts` module for reuse by background runner
- **Background runner**: New `background-runner.ts` module orchestrates the discovery pipeline and updates campaign status in the database
- **Frontend polling**: Updated campaign detail page to poll discovery status every 3 seconds, display elapsed time, and auto-resume polling if discovery is already running on page load
- **Database schema**: Added `discoveryStatus`, `discoveryStartedAt`, and `discoveryError` fields to Campaign model to track background job state
- **Reduced AI research scope**: Lowered `MAX_ENRICHMENT_CANDIDATES` from 100 to 50 and trimmed music keywords list for performance

## Implementation Details

- Discovery no longer blocks the HTTP request — the endpoint returns control immediately after marking the campaign as "RUNNING"
- Frontend safely navigates away during discovery; status persists in the database
- Stale job detection allows recovery if the server restarts mid-discovery
- Draft generation is now a separate, reusable function that can be called independently
- Polling gracefully handles network errors and continues retrying until discovery completes or fails

https://claude.ai/code/session_016ZKhSkVUHi2DXXZrooCCbV