### PR TITLE
Fix CI: revert dotenv version to match pnpm lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@types/pg": "^8.16.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "dotenv": "^17.3.1",
+    "dotenv": "^17.2.3",
     "eslint": "^9",
     "eslint-config-next": "16.1.1",
     "tailwindcss": "^4",


### PR DESCRIPTION
The npm install bumped dotenv from ^17.2.3 to ^17.3.1, causing pnpm install --frozen-lockfile to fail in CI.

https://claude.ai/code/session_016ZKhSkVUHi2DXXZrooCCbV