### PR TITLE
Add public events page support and inline lead creation

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -175,7 +175,9 @@ model Booking {
   splitNotes        String?
 
   // Public visibility for events page
-  isPublic      Boolean  @default(false)
+  isPublic          Boolean  @default(false)
+  publicTitle       String?    // Public-facing event title, e.g. "A Cappella Workshop at UCLA"
+  publicDescription String?    // Short description for the /events page
 
   // Relations
   campaigns     Campaign[]

--- a/src/app/api/bookings/[id]/route.ts
+++ b/src/app/api/bookings/[id]/route.ts
@@ -165,6 +165,9 @@ export async function PATCH(
         paymentStatus: validatedData.paymentStatus,
         internalNotes: validatedData.internalNotes,
         clientNotes: validatedData.clientNotes,
+        isPublic: validatedData.isPublic,
+        publicTitle: validatedData.publicTitle,
+        publicDescription: validatedData.publicDescription,
       },
       include: {
         lead: {

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -8,7 +8,6 @@ import {
 } from '@/lib/validations/booking'
 import { geocodeAddress } from '@/lib/services/geocoding'
 import { sendBookingNotification } from '@/lib/notifications/booking-notification'
-import { discoverLeads } from '@/lib/discovery'
 
 // POST /api/bookings - Create new booking
 export async function POST(request: NextRequest) {
@@ -84,6 +83,9 @@ export async function POST(request: NextRequest) {
         clientNotes: validatedData.clientNotes ?? null,
         availabilityBefore: validatedData.availabilityBefore ?? null,
         availabilityAfter: validatedData.availabilityAfter ?? null,
+        isPublic: validatedData.isPublic ?? false,
+        publicTitle: validatedData.publicTitle ?? null,
+        publicDescription: validatedData.publicDescription ?? null,
       },
       include: {
         lead: {
@@ -99,42 +101,6 @@ export async function POST(request: NextRequest) {
         inquiry: true,
       }
     })
-
-    // Auto-create campaign if booking has location + dates + coordinates
-    let campaign = null
-    if (booking.location && booking.startDate && latitude && longitude) {
-      try {
-        const availBefore = booking.availabilityBefore ?? 3
-        const availAfter = booking.availabilityAfter ?? 3
-        const campaignStart = new Date(booking.startDate)
-        campaignStart.setDate(campaignStart.getDate() - availBefore)
-        const campaignEnd = new Date(booking.endDate || booking.startDate)
-        campaignEnd.setDate(campaignEnd.getDate() + availAfter)
-
-        const campaignName = `${booking.serviceType} - ${lead.firstName} ${lead.lastName} - ${booking.location} (${new Date(booking.startDate).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })})`
-
-        campaign = await prisma.campaign.create({
-          data: {
-            name: campaignName,
-            baseLocation: booking.location,
-            latitude,
-            longitude,
-            radius: 100,
-            startDate: campaignStart,
-            endDate: campaignEnd,
-            bookingId: booking.id,
-            status: 'DRAFT',
-          },
-        })
-
-        // Trigger lead discovery (async - don't block response)
-        discoverLeads(campaign.id).catch((err) => {
-          console.error('Lead discovery failed (non-blocking):', err)
-        })
-      } catch (campaignError) {
-        console.error('Auto-campaign creation failed (non-blocking):', campaignError)
-      }
-    }
 
     // Send booking notification emails (async - don't block response)
     sendBookingNotification({
@@ -153,7 +119,7 @@ export async function POST(request: NextRequest) {
       console.error('Failed to send booking notification:', error)
     })
 
-    return NextResponse.json({ ...booking, campaign }, { status: 201 })
+    return NextResponse.json(booking, { status: 201 })
   } catch (error) {
     return handleApiError(error)
   }

--- a/src/app/api/campaigns/[id]/generate-drafts/route.ts
+++ b/src/app/api/campaigns/[id]/generate-drafts/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { handleApiError, ApiError } from '@/lib/api-error'
 import { renderTemplate } from '@/lib/outreach/template-renderer'
+import { buildDefaultSubject } from '@/lib/outreach/default-subject'
 import { generateDraftsSchema } from '@/lib/validations/email-draft'
 
 export async function POST(
@@ -16,13 +17,14 @@ export async function POST(
     // Verify campaign exists
     const campaign = await prisma.campaign.findUnique({
       where: { id: campaignId },
+      include: { booking: { select: { serviceType: true } } },
     })
     if (!campaign) {
       throw new ApiError(404, 'Campaign not found', 'NOT_FOUND')
     }
 
     // Fetch template
-    let templateSubject = 'Collaboration Opportunity with Deke Sharon'
+    let templateSubject = buildDefaultSubject(campaign.baseLocation, campaign.booking?.serviceType)
     let templateBody = 'Hi {{firstName}},\n\nI\'m reaching out because I\'ll be in the {{baseLocation}} area soon and thought there might be an opportunity to work together.\n\nWould you be open to a conversation?\n\nBest,\nDeke Sharon'
 
     if (templateId) {

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -24,6 +24,8 @@ export async function GET() {
         startDate: true,
         endDate: true,
         location: true,
+        publicTitle: true,
+        publicDescription: true,
         lead: {
           select: {
             organization: true,
@@ -45,6 +47,8 @@ export async function GET() {
       startDate: booking.startDate,
       endDate: booking.endDate,
       location: booking.location,
+      publicTitle: booking.publicTitle ?? null,
+      publicDescription: booking.publicDescription ?? null,
       organization: booking.lead?.organization ?? null,
     }))
 

--- a/src/app/dashboard/campaigns/[id]/page.tsx
+++ b/src/app/dashboard/campaigns/[id]/page.tsx
@@ -19,6 +19,7 @@ import {
   Edit,
   Loader2,
   AlertTriangle,
+  CheckCircle,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -750,6 +751,46 @@ export default function CampaignDetailPage({
 
         <TabsContent value="leads">
           <div className="space-y-4">
+            {/* Contacts Summary */}
+            {campaign.leads.length > 0 && (() => {
+              const active = campaign.leads.filter(l => l.status !== 'REMOVED')
+              const removed = campaign.leads.filter(l => l.status === 'REMOVED')
+              const withEmail = active.filter(l => l.lead.emailVerified || (!l.lead.needsEnrichment && !l.lead.email?.includes?.('@placeholder')))
+              const bySource: Record<string, number> = {}
+              for (const l of active) {
+                bySource[l.source] = (bySource[l.source] || 0) + 1
+              }
+              const sourceLabels: Record<string, string> = {
+                PAST_CLIENT: 'Past Clients',
+                DORMANT: 'Dormant',
+                SIMILAR_ORG: 'Similar Orgs',
+                AI_RESEARCH: 'AI Research',
+                MANUAL_IMPORT: 'Manual',
+              }
+              return (
+                <div className="flex flex-wrap items-center gap-3 rounded-lg border bg-muted/30 px-4 py-3 text-sm">
+                  <span className="font-medium flex items-center gap-1.5">
+                    <Users className="h-4 w-4" />
+                    {active.length} contacts
+                  </span>
+                  <span className="text-muted-foreground">|</span>
+                  <span className="flex items-center gap-1 text-emerald-600">
+                    <CheckCircle className="h-3.5 w-3.5" />
+                    {withEmail.length} emailable
+                  </span>
+                  {Object.entries(bySource).map(([source, count]) => (
+                    <Badge key={source} variant="outline" className="text-xs">
+                      {sourceLabels[source] || source}: {count}
+                    </Badge>
+                  ))}
+                  {removed.length > 0 && (
+                    <span className="text-muted-foreground text-xs">
+                      ({removed.length} removed)
+                    </span>
+                  )}
+                </div>
+              )
+            })()}
             <BulkActionsToolbar
               selectedCount={selectedLeads.length}
               selectedLeadIds={selectedLeads.map(l => l.id)}

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -53,6 +53,8 @@ interface PublicEvent {
   startDate: Date | null;
   endDate: Date | null;
   location: string | null;
+  publicTitle: string | null;
+  publicDescription: string | null;
   organization: string | null;
 }
 
@@ -77,6 +79,8 @@ async function getUpcomingEvents(): Promise<PublicEvent[]> {
         startDate: true,
         endDate: true,
         location: true,
+        publicTitle: true,
+        publicDescription: true,
         lead: {
           select: {
             organization: true,
@@ -96,6 +100,8 @@ async function getUpcomingEvents(): Promise<PublicEvent[]> {
       startDate: b.startDate,
       endDate: b.endDate,
       location: b.location,
+      publicTitle: b.publicTitle ?? null,
+      publicDescription: b.publicDescription ?? null,
       organization: b.lead?.organization ?? null,
     }));
   } catch (error) {
@@ -260,6 +266,20 @@ function EventCard({
               {serviceLabel(event.serviceType)}
             </span>
           </div>
+
+          {/* Event title */}
+          {event.publicTitle && (
+            <h3 className="text-base font-semibold text-[#1a1a1a] mb-1">
+              {event.publicTitle}
+            </h3>
+          )}
+
+          {/* Event description */}
+          {event.publicDescription && (
+            <p className="text-sm text-[#666] mb-2">
+              {event.publicDescription}
+            </p>
+          )}
 
           {/* Location */}
           {event.location && (

--- a/src/components/bookings/booking-form.tsx
+++ b/src/components/bookings/booking-form.tsx
@@ -8,8 +8,18 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
-import { Loader2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { Loader2, Plus } from 'lucide-react';
 
 const SERVICE_TYPES = [
   'ARRANGEMENT',
@@ -52,6 +62,9 @@ const bookingFormSchema = z.object({
   internalNotes: z.string().optional(),
   clientNotes: z.string().optional(),
   tripId: z.string().optional(),
+  isPublic: z.boolean().optional(),
+  publicTitle: z.string().optional(),
+  publicDescription: z.string().optional(),
 });
 
 type BookingFormValues = z.infer<typeof bookingFormSchema>;
@@ -87,6 +100,21 @@ export function BookingForm({
   const [leads, setLeads] = useState<Lead[]>([]);
   const [trips, setTrips] = useState<Trip[]>([]);
   const [loadingLeads, setLoadingLeads] = useState(true);
+  const [showCreateLead, setShowCreateLead] = useState(false);
+  const [creatingLead, setCreatingLead] = useState(false);
+  const [newLead, setNewLead] = useState({ firstName: '', lastName: '', email: '', organization: '' });
+
+  const fetchLeads = async () => {
+    try {
+      const res = await fetch('/api/leads');
+      if (res.ok) {
+        const data = await res.json();
+        setLeads(data);
+      }
+    } catch (error) {
+      console.error('Error fetching leads:', error);
+    }
+  };
 
   useEffect(() => {
     async function fetchData() {
@@ -131,8 +159,42 @@ export function BookingForm({
       internalNotes: initialValues?.internalNotes || '',
       clientNotes: initialValues?.clientNotes || '',
       tripId: initialValues?.tripId || '',
+      isPublic: initialValues?.isPublic || false,
+      publicTitle: initialValues?.publicTitle || '',
+      publicDescription: initialValues?.publicDescription || '',
     },
   });
+
+  const isPublic = form.watch('isPublic');
+
+  const handleCreateLead = async () => {
+    if (!newLead.firstName || !newLead.email) return;
+
+    setCreatingLead(true);
+    try {
+      const res = await fetch('/api/leads', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(newLead),
+      });
+
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.message || 'Failed to create lead');
+      }
+
+      const created = await res.json();
+      await fetchLeads();
+      form.setValue('leadId', created.id);
+      setShowCreateLead(false);
+      setNewLead({ firstName: '', lastName: '', email: '', organization: '' });
+    } catch (error) {
+      console.error('Error creating lead:', error);
+      alert(error instanceof Error ? error.message : 'Failed to create lead');
+    } finally {
+      setCreatingLead(false);
+    }
+  };
 
   return (
     <Form {...form}>
@@ -143,7 +205,19 @@ export function BookingForm({
           name="leadId"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Lead / Client</FormLabel>
+              <div className="flex items-center justify-between">
+                <FormLabel>Lead / Client</FormLabel>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 text-xs"
+                  onClick={() => setShowCreateLead(true)}
+                >
+                  <Plus className="h-3 w-3 mr-1" />
+                  New Lead
+                </Button>
+              </div>
               {loadingLeads ? (
                 <div className="flex items-center gap-2 text-sm text-muted-foreground">
                   <Loader2 className="h-4 w-4 animate-spin" />
@@ -151,7 +225,11 @@ export function BookingForm({
                 </div>
               ) : leads.length === 0 ? (
                 <div className="text-sm text-muted-foreground">
-                  No leads found. Create a lead first via the contact form or campaigns.
+                  No leads found.{' '}
+                  <button type="button" className="underline" onClick={() => setShowCreateLead(true)}>
+                    Create a new lead
+                  </button>{' '}
+                  to get started.
                 </div>
               ) : (
                 <Select onValueChange={field.onChange} value={field.value}>
@@ -417,12 +495,147 @@ export function BookingForm({
           )}
         />
 
+        {/* Public Event Settings */}
+        <div className="rounded-lg border p-4 space-y-4">
+          <FormField
+            control={form.control}
+            name="isPublic"
+            render={({ field }) => (
+              <FormItem className="flex items-center justify-between">
+                <div>
+                  <FormLabel>Show on Public Events Page</FormLabel>
+                  <FormDescription>
+                    Display this booking on the public /events page
+                  </FormDescription>
+                </div>
+                <FormControl>
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+
+          {isPublic && (
+            <>
+              <FormField
+                control={form.control}
+                name="publicTitle"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Event Title</FormLabel>
+                    <FormControl>
+                      <Input placeholder="e.g., A Cappella Workshop at UCLA" {...field} />
+                    </FormControl>
+                    <FormDescription>
+                      Public-facing title shown on the events page
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="publicDescription"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Event Description</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="Brief description for the public events page"
+                        className="resize-none"
+                        rows={2}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </>
+          )}
+        </div>
+
         {/* Submit */}
         <Button type="submit" disabled={isLoading || loadingLeads} className="w-full">
           {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           {submitLabel}
         </Button>
       </form>
+
+      {/* Quick Create Lead Dialog */}
+      <Dialog open={showCreateLead} onOpenChange={setShowCreateLead}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create New Lead</DialogTitle>
+            <DialogDescription>
+              Add a new lead to associate with this booking.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="newLeadFirstName">First Name *</Label>
+                <Input
+                  id="newLeadFirstName"
+                  value={newLead.firstName}
+                  onChange={(e) => setNewLead(prev => ({ ...prev, firstName: e.target.value }))}
+                  placeholder="First name"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="newLeadLastName">Last Name</Label>
+                <Input
+                  id="newLeadLastName"
+                  value={newLead.lastName}
+                  onChange={(e) => setNewLead(prev => ({ ...prev, lastName: e.target.value }))}
+                  placeholder="Last name"
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="newLeadEmail">Email *</Label>
+              <Input
+                id="newLeadEmail"
+                type="email"
+                value={newLead.email}
+                onChange={(e) => setNewLead(prev => ({ ...prev, email: e.target.value }))}
+                placeholder="email@example.com"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="newLeadOrg">Organization</Label>
+              <Input
+                id="newLeadOrg"
+                value={newLead.organization}
+                onChange={(e) => setNewLead(prev => ({ ...prev, organization: e.target.value }))}
+                placeholder="Organization name"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowCreateLead(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleCreateLead}
+              disabled={creatingLead || !newLead.firstName || !newLead.email}
+            >
+              {creatingLead ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Creating...
+                </>
+              ) : (
+                'Create Lead'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </Form>
   );
 }

--- a/src/lib/discovery/draft-generator.ts
+++ b/src/lib/discovery/draft-generator.ts
@@ -7,6 +7,7 @@
 
 import { prisma } from '@/lib/db'
 import { renderTemplate } from '@/lib/outreach/template-renderer'
+import { buildDefaultSubject } from '@/lib/outreach/default-subject'
 
 export interface DraftGenerationResult {
   generated: number
@@ -34,6 +35,7 @@ export async function generateDraftsForCampaign(campaignId: string): Promise<Dra
         select: {
           startDate: true,
           endDate: true,
+          serviceType: true,
         },
       },
     },
@@ -63,7 +65,7 @@ export async function generateDraftsForCampaign(campaignId: string): Promise<Dra
   const servicesLink = `${baseUrl}/services`
 
   // Find template
-  let templateSubject = 'Collaboration Opportunity with Deke Sharon'
+  let templateSubject = buildDefaultSubject(campaign.baseLocation, campaign.booking?.serviceType)
   let templateBody = `Hi {{firstName}},
 
 I'm Deke Sharon, and I'll be in the {{baseLocation}} area{{availabilityDates}} — I'd love to explore working with {{organization}}.

--- a/src/lib/outreach/default-subject.ts
+++ b/src/lib/outreach/default-subject.ts
@@ -1,0 +1,19 @@
+/**
+ * Builds a contextual default email subject based on campaign location and booking service type.
+ */
+
+const SERVICE_LABELS: Record<string, string> = {
+  ARRANGEMENT: 'Arrangement',
+  GROUP_COACHING: 'A Cappella Coaching',
+  INDIVIDUAL_COACHING: 'Vocal Coaching',
+  WORKSHOP: 'A Cappella Workshop',
+  SPEAKING: 'Speaking',
+  MASTERCLASS: 'Masterclass',
+  CONSULTATION: 'Consultation',
+}
+
+export function buildDefaultSubject(baseLocation: string, serviceType?: string | null): string {
+  const label = (serviceType && SERVICE_LABELS[serviceType]) || 'A Cappella'
+  const city = baseLocation.split(',')[0].trim()
+  return `${label} Opportunity in ${city} - Deke Sharon`
+}

--- a/src/lib/validations/booking.ts
+++ b/src/lib/validations/booking.ts
@@ -48,6 +48,9 @@ export const createBookingSchema = z.object({
   clientNotes: z.string().optional().nullable(),
   availabilityBefore: z.number().int().min(0).max(30).optional().nullable(),
   availabilityAfter: z.number().int().min(0).max(30).optional().nullable(),
+  isPublic: z.boolean().optional(),
+  publicTitle: z.string().max(200).optional().nullable(),
+  publicDescription: z.string().max(1000).optional().nullable(),
 })
 
 // Query filters for listing bookings
@@ -77,6 +80,8 @@ export const updateBookingSchema = z.object({
   availabilityBefore: z.number().int().min(0).max(30).optional().nullable(),
   availabilityAfter: z.number().int().min(0).max(30).optional().nullable(),
   isPublic: z.boolean().optional(),
+  publicTitle: z.string().max(200).optional().nullable(),
+  publicDescription: z.string().max(1000).optional().nullable(),
 })
 
 // Type exports


### PR DESCRIPTION
## Summary
This PR adds the ability to showcase bookings on a public events page and streamlines the booking creation workflow by allowing users to quickly create leads directly from the booking form.

## Key Changes

### Public Events Page Support
- Added `isPublic`, `publicTitle`, and `publicDescription` fields to the Booking model to control visibility and presentation on the `/events` page
- Updated the public events page to display custom event titles and descriptions when available
- Added a new "Public Event Settings" section in the booking form with a toggle and conditional fields for event details
- Created `buildDefaultSubject()` utility in `src/lib/outreach/default-subject.ts` to generate contextual email subjects based on location and service type

### Inline Lead Creation
- Added a "New Lead" button in the booking form's lead selector that opens a dialog
- Implemented `handleCreateLead()` to create leads via `/api/leads` endpoint without leaving the booking form
- New leads are automatically selected after creation, improving the user experience
- Updated the "no leads found" message to include a link to the quick create dialog

### Campaign Auto-Creation Removal
- Removed automatic campaign creation from the booking POST endpoint to simplify the workflow
- Removed the `discoverLeads()` call that was triggered during booking creation
- Removed the `discoverLeads` import from the bookings API route

### Campaign Details Enhancement
- Added a contacts summary section in the campaign leads tab showing:
  - Total active contacts
  - Count of emailable contacts
  - Breakdown by source (Past Clients, Dormant, Similar Orgs, AI Research, Manual)
  - Count of removed contacts

### Database & Validation
- Updated Prisma schema to add `publicTitle` and `publicDescription` fields to Booking model
- Updated booking validation schemas to include the new public event fields with appropriate constraints
- Updated booking API routes (POST and PATCH) to handle the new fields

## Implementation Details
- The public event settings section conditionally renders title and description fields only when `isPublic` is toggled on
- Lead creation dialog includes validation for required fields (first name and email)
- The new lead creation flow automatically refreshes the leads list and selects the newly created lead
- Email subject generation is now centralized and reusable across the outreach system

https://claude.ai/code/session_01Kz2jY6jSKqqVV1VzKGB436