### PR TITLE
Fix new booking page: remove auto-campaign, add public event fields

### DIFF
--- a/src/app/api/bookings/quick/route.ts
+++ b/src/app/api/bookings/quick/route.ts
@@ -3,8 +3,6 @@ import { z } from "zod";
 import { prisma } from "@/lib/db";
 import { handleApiError, ApiError } from "@/lib/api-error";
 import { sendBookingNotification } from "@/lib/notifications/booking-notification";
-import { geocodeAddress } from "@/lib/services/geocoding";
-import { discoverLeads } from "@/lib/discovery";
 
 // Zero-friction booking creation
 // Auto-creates Lead if needed, creates Booking, optionally links to Trip
@@ -26,6 +24,9 @@ const QuickBookingSchema = z.object({
   tripId: z.string().nullable().optional(),
   availabilityBefore: z.number().int().min(0).max(30).nullable().optional(),
   availabilityAfter: z.number().int().min(0).max(30).nullable().optional(),
+  isPublic: z.boolean().optional(),
+  publicTitle: z.string().max(200).nullable().optional(),
+  publicDescription: z.string().max(1000).nullable().optional(),
 });
 
 export async function POST(request: NextRequest) {
@@ -37,7 +38,7 @@ export async function POST(request: NextRequest) {
       return ApiError.badRequest(result.error.issues[0].message);
     }
 
-    const { client, serviceType, startDate, endDate, location, amount, depositPaid, notes, tripId, availabilityBefore, availabilityAfter } = result.data;
+    const { client, serviceType, startDate, endDate, location, amount, depositPaid, notes, tripId, availabilityBefore, availabilityAfter, isPublic, publicTitle, publicDescription } = result.data;
 
     // Step 1: Find or create Lead
     let lead = await prisma.lead.findUnique({
@@ -93,6 +94,9 @@ export async function POST(request: NextRequest) {
         internalNotes: notes || null,
         availabilityBefore: availabilityBefore ?? null,
         availabilityAfter: availabilityAfter ?? null,
+        isPublic: isPublic ?? false,
+        publicTitle: publicTitle || null,
+        publicDescription: publicDescription || null,
       },
       include: {
         lead: {
@@ -129,60 +133,7 @@ export async function POST(request: NextRequest) {
       console.error('Failed to send booking notification:', error);
     });
 
-    // Step 4: Auto-create campaign if booking has location + startDate
-    let campaign = null;
-    if (location && startDate) {
-      try {
-        const geoResult = await geocodeAddress(location);
-        if (geoResult) {
-          const bookingStart = new Date(startDate);
-          const bookingEnd = endDate ? new Date(endDate) : bookingStart;
-          const campaignStart = new Date(bookingStart);
-          campaignStart.setDate(campaignStart.getDate() - (availabilityBefore ?? 3));
-          const campaignEnd = new Date(bookingEnd);
-          campaignEnd.setDate(campaignEnd.getDate() + (availabilityAfter ?? 3));
-
-          campaign = await prisma.campaign.create({
-            data: {
-              name: `${serviceType} - ${location} (${bookingStart.toLocaleDateString("en-US", { month: "short", day: "numeric" })})`,
-              baseLocation: location,
-              latitude: geoResult.latitude,
-              longitude: geoResult.longitude,
-              radius: 100,
-              startDate: campaignStart,
-              endDate: campaignEnd,
-              bookingId: booking.id,
-              status: "DRAFT",
-            },
-          });
-
-          // Trigger lead discovery async (non-blocking)
-          discoverLeads(campaign.id).catch((err) => {
-            console.error("Lead discovery failed (non-blocking):", err);
-          });
-        }
-      } catch (err) {
-        console.error("Campaign auto-creation failed (non-blocking):", err);
-        // Don't fail the booking — campaign is a bonus
-      }
-    }
-
-    return NextResponse.json(
-      {
-        ...booking,
-        ...(campaign && {
-          campaign: {
-            id: campaign.id,
-            name: campaign.name,
-            status: campaign.status,
-            radius: campaign.radius,
-            startDate: campaign.startDate,
-            endDate: campaign.endDate,
-          },
-        }),
-      },
-      { status: 201 }
-    );
+    return NextResponse.json(booking, { status: 201 });
   } catch (error) {
     return handleApiError(error);
   }

--- a/src/app/dashboard/bookings/new/page.tsx
+++ b/src/app/dashboard/bookings/new/page.tsx
@@ -9,7 +9,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
-import { ArrowLeft, Loader2, Rocket, Save } from 'lucide-react';
+import { ArrowLeft, Globe, Loader2, Rocket, Save } from 'lucide-react';
 import { AvailabilityWindow } from '@/components/bookings/availability-window';
 
 const SERVICE_TYPES = [
@@ -54,6 +54,9 @@ function NewBookingForm() {
     availabilityBefore: 3,
     availabilityAfter: 3,
     campaignRadius: 100,
+    isPublic: false,
+    publicTitle: '',
+    publicDescription: '',
   });
 
   useEffect(() => {
@@ -63,7 +66,7 @@ function NewBookingForm() {
       .catch(() => setTrips([]));
   }, []);
 
-  const handleChange = (field: string, value: string | number) => {
+  const handleChange = (field: string, value: string | number | boolean) => {
     setForm(prev => ({ ...prev, [field]: value }));
   };
 
@@ -97,6 +100,9 @@ function NewBookingForm() {
         tripId: form.tripId || null,
         availabilityBefore: form.availabilityBefore,
         availabilityAfter: form.availabilityAfter,
+        isPublic: form.isPublic,
+        publicTitle: form.publicTitle || null,
+        publicDescription: form.publicDescription || null,
       };
 
       if (launch) {
@@ -117,7 +123,6 @@ function NewBookingForm() {
       const result = await response.json();
 
       if (result.campaign) {
-        // Campaign was created (either via auto-launch or auto-create)
         router.push(`/dashboard/campaigns/${result.campaign.id}`);
       } else {
         router.push(`/dashboard/bookings/${result.id}`);
@@ -320,6 +325,47 @@ function NewBookingForm() {
                     </div>
                   </div>
                 )}
+
+                {/* Public Event Section */}
+                <div className="space-y-4 pt-4 border-t">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <Globe className="h-4 w-4 text-muted-foreground" />
+                      <h3 className="font-medium text-sm text-muted-foreground uppercase tracking-wide">Public Event</h3>
+                    </div>
+                    <Switch
+                      id="isPublic"
+                      checked={form.isPublic}
+                      onCheckedChange={(v) => handleChange('isPublic', v)}
+                    />
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Show this booking on the public events page at dekesharon.com/events
+                  </p>
+                  {form.isPublic && (
+                    <div className="space-y-4">
+                      <div>
+                        <Label htmlFor="publicTitle">Event Title</Label>
+                        <Input
+                          id="publicTitle"
+                          placeholder="A Cappella Workshop at UCLA"
+                          value={form.publicTitle}
+                          onChange={(e) => handleChange('publicTitle', e.target.value)}
+                        />
+                      </div>
+                      <div>
+                        <Label htmlFor="publicDescription">Event Description</Label>
+                        <Textarea
+                          id="publicDescription"
+                          placeholder="Join Deke Sharon for an immersive a cappella workshop..."
+                          rows={3}
+                          value={form.publicDescription}
+                          onChange={(e) => handleChange('publicDescription', e.target.value)}
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
               </CardContent>
             </Card>
           </div>
@@ -427,7 +473,7 @@ function NewBookingForm() {
                   ) : (
                     <>
                       <Save className="mr-2 h-4 w-4" />
-                      Save Draft
+                      Save Booking
                     </>
                   )}
                 </Button>


### PR DESCRIPTION
- Remove auto-campaign creation from /api/bookings/quick (campaigns are now only created via "Save & Launch Campaign" or the detail page's "Launch Campaign" button)
- Rename misleading "Save Draft" button to "Save Booking" (the API creates CONFIRMED bookings, not drafts)
- Add isPublic, publicTitle, publicDescription fields to the new booking form and quick API so users can mark bookings as public events during creation

https://claude.ai/code/session_01Kz2jY6jSKqqVV1VzKGB436