### PR TITLE
Add name validation and title stripping for contact enrichment

### DIFF
--- a/src/app/api/campaigns/[id]/generate-drafts/route.ts
+++ b/src/app/api/campaigns/[id]/generate-drafts/route.ts
@@ -98,8 +98,14 @@ export async function POST(
         continue
       }
 
+      // Use org-based greeting when no real person name is available
+      let greeting = cl.lead.firstName
+      if (cl.lead.firstName === 'Contact' && cl.lead.lastName?.startsWith('at ')) {
+        greeting = cl.lead.organization ? `${cl.lead.organization} team` : 'there'
+      }
+
       const vars = {
-        firstName: cl.lead.firstName,
+        firstName: greeting,
         lastName: cl.lead.lastName,
         organization: cl.lead.organization || '',
         email: cl.lead.email,

--- a/src/lib/discovery/draft-generator.ts
+++ b/src/lib/discovery/draft-generator.ts
@@ -113,8 +113,14 @@ Deke Sharon
       continue
     }
 
+    // Use org-based greeting when no real person name is available
+    let greeting = cl.lead.firstName
+    if (cl.lead.firstName === 'Contact' && cl.lead.lastName?.startsWith('at ')) {
+      greeting = cl.lead.organization ? `${cl.lead.organization} team` : 'there'
+    }
+
     const vars: Record<string, string> = {
-      firstName: cl.lead.firstName,
+      firstName: greeting,
       lastName: cl.lead.lastName,
       organization: cl.lead.organization || '',
       contactTitle: cl.lead.contactTitle || '',

--- a/src/lib/enrichment/__tests__/name-validator.test.ts
+++ b/src/lib/enrichment/__tests__/name-validator.test.ts
@@ -1,0 +1,107 @@
+import { isValidContactName, stripTitlePrefix } from '../name-validator'
+
+describe('isValidContactName', () => {
+  it('accepts valid two-word names', () => {
+    expect(isValidContactName('Jane Smith')).toBe(true)
+    expect(isValidContactName('John Lee')).toBe(true)
+    expect(isValidContactName('Kim O\'Brien')).toBe(true)
+  })
+
+  it('accepts valid three-word names', () => {
+    expect(isValidContactName('Mary Lou Henderson')).toBe(true)
+    expect(isValidContactName('Jean Pierre Dupont')).toBe(true)
+  })
+
+  it('rejects empty or blank strings', () => {
+    expect(isValidContactName('')).toBe(false)
+    expect(isValidContactName('  ')).toBe(false)
+  })
+
+  it('rejects street addresses', () => {
+    expect(isValidContactName('Greenview Ave Ottawa')).toBe(false)
+    expect(isValidContactName('Main Street')).toBe(false)
+    expect(isValidContactName('Oak Blvd')).toBe(false)
+    expect(isValidContactName('Park Road')).toBe(false)
+  })
+
+  it('rejects navigation/menu text', () => {
+    expect(isValidContactName('Broadway Videos Media Menu Welcome')).toBe(false)
+    expect(isValidContactName('Home About')).toBe(false)
+    expect(isValidContactName('Login Search')).toBe(false)
+  })
+
+  it('rejects too many words (>3)', () => {
+    expect(isValidContactName('One Two Three Four')).toBe(false)
+    expect(isValidContactName('Some Long Navigation Text Here')).toBe(false)
+  })
+
+  it('rejects single-word non-names', () => {
+    expect(isValidContactName('Contact')).toBe(false)
+    expect(isValidContactName('Admin')).toBe(false)
+    expect(isValidContactName('Choir')).toBe(false)
+    expect(isValidContactName('Music')).toBe(false)
+  })
+
+  it('accepts single-word proper names', () => {
+    expect(isValidContactName('Katarina')).toBe(true)
+    expect(isValidContactName('Deke')).toBe(true)
+  })
+
+  it('allows Dr at start (honorific, not drive)', () => {
+    expect(isValidContactName('Dr Smith')).toBe(true)
+  })
+
+  it('rejects Drive in non-first position', () => {
+    expect(isValidContactName('Oak Drive')).toBe(false)
+  })
+})
+
+describe('stripTitlePrefix', () => {
+  it('strips Treasurer prefix', () => {
+    const result = stripTitlePrefix('Treasurer Katarina Michalyshyn')
+    expect(result.name).toBe('Katarina Michalyshyn')
+    expect(result.title).toBe('Treasurer')
+  })
+
+  it('strips President prefix', () => {
+    const result = stripTitlePrefix('President John Lee')
+    expect(result.name).toBe('John Lee')
+    expect(result.title).toBe('President')
+  })
+
+  it('strips Vice President prefix', () => {
+    const result = stripTitlePrefix('Vice President Sarah Jones')
+    expect(result.name).toBe('Sarah Jones')
+    expect(result.title).toBe('Vice President')
+  })
+
+  it('strips Director prefix', () => {
+    const result = stripTitlePrefix('Director Maria Santos')
+    expect(result.name).toBe('Maria Santos')
+    expect(result.title).toBe('Director')
+  })
+
+  it('returns original name when no prefix', () => {
+    const result = stripTitlePrefix('Jane Smith')
+    expect(result.name).toBe('Jane Smith')
+    expect(result.title).toBeNull()
+  })
+
+  it('does not strip prefix if nothing remains', () => {
+    const result = stripTitlePrefix('Treasurer')
+    expect(result.name).toBe('Treasurer')
+    expect(result.title).toBeNull()
+  })
+
+  it('handles empty/null-ish input', () => {
+    const result = stripTitlePrefix('')
+    expect(result.name).toBe('')
+    expect(result.title).toBeNull()
+  })
+
+  it('normalizes title casing', () => {
+    const result = stripTitlePrefix('treasurer jane doe')
+    expect(result.title).toBe('Treasurer')
+    expect(result.name).toBe('jane doe')
+  })
+})

--- a/src/lib/enrichment/index.ts
+++ b/src/lib/enrichment/index.ts
@@ -7,6 +7,7 @@
  */
 
 import { scrapeWebsite, type ScrapedEmail } from './website-scraper'
+import { isValidContactName, stripTitlePrefix } from './name-validator'
 
 export interface EnrichmentResult {
   email: string | null
@@ -68,18 +69,25 @@ export async function enrichOrganization(
       return baseResult
     }
 
-    // Parse name from the scraped email context
+    // Parse name from the scraped email context (with validation)
     let firstName = 'Contact'
     let lastName = `at ${orgName}`
+    let inferredTitle: string | null = null
 
     if (bestEmail.name) {
-      const nameParts = bestEmail.name.split(' ')
-      if (nameParts.length >= 2) {
-        firstName = nameParts[0]
-        lastName = nameParts.slice(1).join(' ')
-      } else if (nameParts.length === 1) {
-        firstName = nameParts[0]
+      const { name: cleanName, title: strippedTitle } = stripTitlePrefix(bestEmail.name)
+      inferredTitle = strippedTitle
+
+      if (isValidContactName(cleanName)) {
+        const nameParts = cleanName.split(' ')
+        if (nameParts.length >= 2) {
+          firstName = nameParts[0]
+          lastName = nameParts.slice(1).join(' ')
+        } else if (nameParts.length === 1) {
+          firstName = nameParts[0]
+        }
       }
+      // else: keep default "Contact" / "at {orgName}"
     }
 
     const titleInfo = bestEmail.title ? ` (${bestEmail.title})` : ''
@@ -89,7 +97,7 @@ export async function enrichOrganization(
       email: bestEmail.email,
       firstName,
       lastName,
-      contactTitle: bestEmail.title || null,
+      contactTitle: bestEmail.title || inferredTitle || null,
       emailType: bestEmail.type,
       emailVerified: true,
       needsEnrichment: false,

--- a/src/lib/enrichment/name-validator.ts
+++ b/src/lib/enrichment/name-validator.ts
@@ -1,0 +1,103 @@
+/**
+ * Name Validator for Contact Enrichment
+ *
+ * Validates scraped contact names to filter out garbage data like
+ * street addresses, navigation menu text, and other non-name content.
+ * Also strips role/title prefixes from names.
+ */
+
+// Street-related words that indicate an address, not a name
+const ADDRESS_WORDS = new Set([
+  'ave', 'avenue', 'st', 'street', 'rd', 'road', 'blvd', 'boulevard',
+  'ln', 'lane', 'way', 'ct', 'court', 'pl', 'place', 'hwy', 'highway',
+  'drive', 'cres', 'crescent', 'pkwy', 'parkway', 'terr', 'terrace',
+])
+
+// Words commonly scraped from website navigation/UI, not real names
+const WEB_JUNK_WORDS = new Set([
+  'menu', 'welcome', 'videos', 'media', 'home', 'about', 'contact',
+  'login', 'search', 'subscribe', 'newsletter', 'donate', 'navigation',
+  'footer', 'header', 'sidebar', 'click', 'here', 'read', 'more',
+  'copyright', 'privacy', 'policy', 'terms', 'blog', 'news', 'events',
+  'gallery', 'photos', 'calendar', 'join', 'register', 'signup',
+  'shop', 'store', 'cart', 'checkout', 'account', 'settings',
+])
+
+// Single-word values that are clearly not personal names
+const SINGLE_WORD_BLOCKLIST = new Set([
+  'contact', 'info', 'admin', 'office', 'team', 'staff', 'board',
+  'choir', 'music', 'group', 'ensemble', 'chorus', 'orchestra',
+  'singers', 'voices', 'director', 'president', 'treasurer',
+  'secretary', 'coordinator', 'manager', 'webmaster',
+])
+
+// Role/title prefixes that should be stripped from names
+const TITLE_PREFIXES_REGEX = /^(treasurer|president|vice\s+president|secretary|director|chair(?:person)?|board\s+member|coordinator|manager|minister|pastor|reverend|deacon)\s+/i
+
+/**
+ * Check if a scraped name looks like a real person's name.
+ *
+ * Rejects addresses, navigation text, and other non-name content.
+ * Should be called AFTER stripTitlePrefix.
+ */
+export function isValidContactName(name: string): boolean {
+  if (!name || name.trim().length === 0) return false
+
+  const trimmed = name.trim()
+  const words = trimmed.split(/\s+/)
+
+  // Too many words — likely nav/menu text
+  if (words.length > 3) return false
+
+  // Single word — check against blocklist
+  if (words.length === 1) {
+    if (SINGLE_WORD_BLOCKLIST.has(words[0].toLowerCase())) return false
+  }
+
+  const lowerWords = words.map(w => w.toLowerCase())
+
+  // Check for address words (skip "Dr" at position 0 since it's an honorific)
+  for (let i = 0; i < lowerWords.length; i++) {
+    const word = lowerWords[i]
+    // "Dr" and "Drive" overlap — only treat as address if not first word
+    if (word === 'drive' || word === 'dr') {
+      if (i > 0) return false
+      continue
+    }
+    // "St" can be "Saint" when first — only reject in non-first position
+    if (word === 'st' || word === 'street') {
+      if (i > 0) return false
+      continue
+    }
+    if (ADDRESS_WORDS.has(word)) return false
+  }
+
+  // Check for web junk words
+  for (const word of lowerWords) {
+    if (WEB_JUNK_WORDS.has(word)) return false
+  }
+
+  return true
+}
+
+/**
+ * Strip a role/title prefix from a name and return both parts.
+ *
+ * e.g. "Treasurer Katarina Michalyshyn" -> { name: "Katarina Michalyshyn", title: "Treasurer" }
+ * e.g. "Jane Smith" -> { name: "Jane Smith", title: null }
+ */
+export function stripTitlePrefix(name: string): { name: string; title: string | null } {
+  if (!name) return { name, title: null }
+
+  const match = TITLE_PREFIXES_REGEX.exec(name.trim())
+  if (match) {
+    const title = match[1].trim().replace(/\b\w/g, c => c.toUpperCase())
+    const remainder = name.trim().substring(match[0].length).trim()
+    // Only strip if remainder still looks like a name (at least one word)
+    if (remainder.length > 0) {
+      return { name: remainder, title }
+    }
+  }
+
+  return { name: name.trim(), title: null }
+}

--- a/src/lib/enrichment/website-scraper.ts
+++ b/src/lib/enrichment/website-scraper.ts
@@ -9,6 +9,8 @@
  * Music-org-specific patterns: staff pages, "Music Director:" labels, board lists.
  */
 
+import { isValidContactName, stripTitlePrefix } from './name-validator'
+
 export interface ScrapedEmail {
   email: string
   name: string | null
@@ -116,7 +118,18 @@ function extractNameNearEmail(text: string, emailIndex: number): { name: string 
     names.push(match[1]?.trim() || match[0].trim())
   }
 
-  const name = names.length > 0 ? names[names.length - 1] : null
+  let name = names.length > 0 ? names[names.length - 1] : null
+
+  // Validate and clean the extracted name
+  if (name) {
+    const stripped = stripTitlePrefix(name)
+    const inferredTitle = stripped.title || title
+    if (!isValidContactName(stripped.name)) {
+      return { name: null, title: inferredTitle }
+    }
+    return { name: stripped.name, title: inferredTitle }
+  }
+
   return { name, title }
 }
 
@@ -171,12 +184,22 @@ function extractTitleEmailPairs(text: string): ScrapedEmail[] {
         const normalizedTitle = tMatch[0].trim().replace(/\b\w/g, c => c.toUpperCase())
         const emailType = classifyEmail(email)
 
+        // Validate and clean name candidates
+        let validName: string | null = null
+        for (const candidate of names) {
+          const stripped = stripTitlePrefix(candidate)
+          if (isValidContactName(stripped.name)) {
+            validName = stripped.name
+            break
+          }
+        }
+
         foundEmails.add(email)
         results.push({
           email,
-          name: names.length > 0 ? names[0] : null,
+          name: validName,
           title: normalizedTitle,
-          type: names.length > 0 || emailType === 'personal' ? 'personal' : emailType,
+          type: validName || emailType === 'personal' ? 'personal' : emailType,
         })
       }
     }


### PR DESCRIPTION
## Summary
Adds robust name validation and title prefix stripping to the contact enrichment pipeline to filter out garbage data (street addresses, navigation text, etc.) and extract clean contact names with inferred titles.

## Key Changes

- **New `name-validator` module** (`src/lib/enrichment/name-validator.ts`):
  - `isValidContactName()`: Validates scraped names by rejecting addresses, web junk words, single-word non-names, and overly long text fragments
  - `stripTitlePrefix()`: Extracts role/title prefixes (Treasurer, President, Vice President, Director, etc.) from names and returns both the clean name and inferred title
  - Comprehensive blocklists for address words, web UI junk, and non-name single words

- **Integration into scraping pipeline** (`src/lib/enrichment/website-scraper.ts`):
  - `extractNameNearEmail()`: Now validates extracted names and strips titles before returning
  - `extractTitleEmailPairs()`: Validates name candidates and only includes names that pass validation

- **Integration into enrichment logic** (`src/lib/enrichment/index.ts`):
  - Applies name validation and title stripping when parsing best email results
  - Falls back to default "Contact at {orgName}" when extracted name fails validation
  - Preserves inferred titles from stripped prefixes

- **Improved greeting logic** (`src/app/api/campaigns/[id]/generate-drafts/route.ts` and `src/lib/discovery/draft-generator.ts`):
  - Uses organization-based greetings ("team name team" or "there") when no real person name is available
  - Detects the default "Contact at {orgName}" pattern and substitutes appropriate greeting

- **Comprehensive test coverage** (`src/lib/enrichment/__tests__/name-validator.test.ts`):
  - 20+ test cases covering valid names, addresses, navigation text, single words, and title stripping

## Implementation Details

- Address detection is context-aware: "Dr" and "St" are allowed in first position (honorific/saint names) but rejected elsewhere
- Title prefix matching is case-insensitive but normalized to title case in output
- Name validation only strips titles if a valid name remains after stripping
- Graceful fallback: invalid names result in generic "Contact" greeting rather than malformed data

https://claude.ai/code/session_013cYhPMa8x1HyySTbkrTgXp