### PR TITLE
Redesign dashboard: minimal sidebar + actionable Today page

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -30,19 +30,20 @@ async function getPendingInquiryCount(): Promise<number> {
   }
 }
 
-const navItems = [
-  { href: "/dashboard", label: "COMMAND CENTER", icon: "LayoutDashboard" as const },
-  { href: "/dashboard/inquiries", label: "INQUIRIES", icon: "MessageSquare" as const, badgeKey: "inquiries" as const },
+const primaryNav = [
+  { href: "/dashboard", label: "TODAY", icon: "Zap" as const, badgeKey: "today" as const },
   { href: "/dashboard/bookings", label: "BOOKINGS", icon: "Calendar" as const },
-  { href: "/dashboard/orders", label: "ORDERS", icon: "Package" as const },
-  { href: "/dashboard/engagements", label: "ENGAGEMENTS", icon: "Briefcase" as const },
-  { href: "/dashboard/expenses", label: "EXPENSES", icon: "DollarSign" as const },
-  { href: "/dashboard/campaigns", label: "LEAD GEN", icon: "Rocket" as const },
-  { href: "/dashboard/contacts", label: "CONTACTS", icon: "Users" as const, badgeKey: "contacts" as const },
-  { href: "/dashboard/trips", label: "TRIPS", icon: "Plane" as const },
-  { href: "/dashboard/pipeline", label: "PIPELINE", icon: "GitBranch" as const },
+  { href: "/dashboard/contacts", label: "LEADS", icon: "Users" as const, badgeKey: "leads" as const },
   { href: "/dashboard/calendar", label: "CALENDAR", icon: "CalendarDays" as const },
-  { href: "/dashboard/analytics", label: "ANALYTICS", icon: "BarChart3" as const },
+];
+
+const insightNav = [
+  { href: "/dashboard/analytics", label: "Analytics", icon: "BarChart3" as const },
+  { href: "/dashboard/pipeline", label: "Pipeline", icon: "GitBranch" as const },
+  { href: "/dashboard/orders", label: "Orders", icon: "Package" as const },
+  { href: "/dashboard/expenses", label: "Expenses", icon: "DollarSign" as const },
+  { href: "/dashboard/trips", label: "Trips", icon: "Plane" as const },
+  { href: "/dashboard/engagements", label: "Engagements", icon: "Briefcase" as const },
 ];
 
 export default async function DashboardLayout({
@@ -56,16 +57,18 @@ export default async function DashboardLayout({
   ]);
 
   const badgeCounts = {
-    contacts: newRequestCount,
-    inquiries: pendingInquiryCount,
+    leads: newRequestCount,
+    today: pendingInquiryCount,
   };
 
   return (
     <div className="min-h-screen bg-[#FAFAF8]">
-      {/* Desktop sidebar */}
-      <DashboardSidebar navItems={navItems} badgeCounts={badgeCounts} />
+      <DashboardSidebar
+        primaryNav={primaryNav}
+        insightNav={insightNav}
+        badgeCounts={badgeCounts}
+      />
 
-      {/* Main content */}
       <main className="lg:pl-[260px] pb-20 lg:pb-0">
         <div className="mx-auto max-w-7xl p-6 md:p-8">{children}</div>
       </main>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,55 +1,23 @@
 import Link from "next/link"
 import { prisma } from "@/lib/db"
 import {
-  Calendar,
-  Users,
-  TrendingUp,
-  ArrowRight,
-  CheckCircle2,
-  MapPin,
-  Clock,
+  MessageSquare,
+  Briefcase,
   DollarSign,
-  AlertCircle,
-  CalendarDays,
+  Rocket,
+  ArrowRight,
+  Calendar,
+  MapPin,
+  Zap,
 } from "lucide-react"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 
 export const dynamic = "force-dynamic"
 export const revalidate = 0
 
-function getGreeting(): string {
-  const hour = new Date().getHours()
-  if (hour < 12) return "Good morning"
-  if (hour < 17) return "Good afternoon"
-  return "Good evening"
-}
-
-function formatDate(date: Date): string {
-  return date.toLocaleDateString("en-US", {
-    weekday: "long",
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  })
-}
-
-function formatShortDate(date: Date | null): string {
-  if (!date) return "No date"
-  return date.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  })
-}
-
-function formatServiceType(type: string): string {
-  return type
-    .replace(/_/g, " ")
-    .toLowerCase()
-    .replace(/\b\w/g, (c) => c.toUpperCase())
-}
+// ─── Formatting helpers ───────────────────────────────────────────
 
 function formatCurrency(value: number): string {
   return new Intl.NumberFormat("en-US", {
@@ -59,111 +27,71 @@ function formatCurrency(value: number): string {
   }).format(value)
 }
 
-function getPaymentStatusBadge(status: string) {
-  switch (status) {
-    case "UNPAID":
-      return "bg-red-50 text-red-700 border-red-200"
-    case "DEPOSIT_PAID":
-      return "bg-amber-50 text-amber-700 border-amber-200"
-    case "PAID_IN_FULL":
-      return "bg-emerald-50 text-emerald-700 border-emerald-200"
-    case "OVERDUE":
-      return "bg-red-100 text-red-800 border-red-300"
-    case "REFUNDED":
-      return "bg-stone-100 text-stone-600 border-stone-200"
-    default:
-      return "bg-stone-100 text-stone-600 border-stone-200"
-  }
+function formatServiceType(type: string): string {
+  return type
+    .replace(/_/g, " ")
+    .toLowerCase()
+    .replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
-function getEngagementStatusBadge(status: string) {
-  switch (status) {
-    case "PREP":
-      return "bg-blue-50 text-blue-700 border-blue-200"
-    case "READY":
-      return "bg-emerald-50 text-emerald-700 border-emerald-200"
-    case "DELIVERED":
-      return "bg-sky-50 text-sky-700 border-sky-200"
-    case "FOLLOW_UP":
-      return "bg-amber-50 text-amber-700 border-amber-200"
-    default:
-      return "bg-stone-100 text-stone-600 border-stone-200"
-  }
+function formatShortDate(date: Date | null): string {
+  if (!date) return "TBD"
+  const now = new Date()
+  const sameYear = date.getFullYear() === now.getFullYear()
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    ...(sameYear ? {} : { year: "numeric" }),
+  })
 }
 
-async function getDashboardData() {
+function formatTodayDate(): string {
+  return new Date().toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  })
+}
+
+// ─── Data fetching ────────────────────────────────────────────────
+
+async function getTodayData() {
   const now = new Date()
   const thirtyDaysFromNow = new Date()
   thirtyDaysFromNow.setDate(thirtyDaysFromNow.getDate() + 30)
 
   try {
     const [
-      upcomingBookingsCount,
-      revenuePipelineResult,
-      outstandingBalanceResult,
-      activeLeadsCount,
-      nextUpBookings,
+      pendingInquiries,
       needsPrepBookings,
       paymentDueBookings,
       noCampaignBookings,
-      recentContacts,
+      upcomingBookingsCount,
+      revenuePipelineResult,
+      activeLeadsCount,
+      nextUpBookings,
     ] = await Promise.all([
-      // KPI 1: Upcoming Bookings (next 30 days)
-      prisma.booking.count({
-        where: {
-          status: { in: ["CONFIRMED", "IN_PROGRESS", "PENDING"] },
-          startDate: { gte: now, lte: thirtyDaysFromNow },
-        },
-      }),
-
-      // KPI 2: Revenue Pipeline — sum of amount for confirmed/in-progress
-      prisma.booking.aggregate({
-        _sum: { amount: true },
-        where: {
-          status: { in: ["CONFIRMED", "IN_PROGRESS"] },
-        },
-      }),
-
-      // KPI 3: Outstanding Balance
-      prisma.booking.aggregate({
-        _sum: { balanceDue: true },
-        where: {
-          paymentStatus: { notIn: ["PAID_IN_FULL", "REFUNDED"] },
-          balanceDue: { gt: 0 },
-        },
-      }),
-
-      // KPI 4: Active Leads
-      prisma.lead.count({
-        where: {
-          status: {
-            in: ["NEW", "CONTACTED", "QUALIFIED", "PROPOSAL_SENT", "NEGOTIATING"],
-          },
-        },
-      }),
-
-      // Next Up: next 5 upcoming bookings
-      prisma.booking.findMany({
-        where: {
-          status: { in: ["CONFIRMED", "IN_PROGRESS", "PENDING"] },
-          startDate: { gte: now },
-        },
+      // RESPOND: Pending inquiries
+      prisma.inquiry.findMany({
+        where: { status: "PENDING" },
         include: {
           lead: {
             select: {
               firstName: true,
               lastName: true,
+              organization: true,
             },
           },
         },
-        orderBy: { startDate: "asc" },
-        take: 5,
+        orderBy: { createdAt: "desc" },
+        take: 10,
       }),
 
-      // Action Items: Needs Prep
+      // PREP: Bookings needing preparation (next 30 days)
       prisma.booking.findMany({
         where: {
           startDate: { gte: now, lte: thirtyDaysFromNow },
+          status: { in: ["CONFIRMED", "IN_PROGRESS", "PENDING"] },
           OR: [
             { engagementStatus: null },
             { engagementStatus: "PREP" },
@@ -177,7 +105,7 @@ async function getDashboardData() {
         orderBy: { startDate: "asc" },
       }),
 
-      // Action Items: Payment Due
+      // COLLECT: Unpaid/overdue bookings
       prisma.booking.findMany({
         where: {
           paymentStatus: { in: ["UNPAID", "OVERDUE"] },
@@ -191,7 +119,7 @@ async function getDashboardData() {
         orderBy: { startDate: "asc" },
       }),
 
-      // Action Items: No Campaign
+      // GROW: Confirmed bookings with no campaign
       prisma.booking.findMany({
         where: {
           status: { in: ["CONFIRMED", "IN_PROGRESS"] },
@@ -210,431 +138,404 @@ async function getDashboardData() {
         orderBy: { startDate: "asc" },
       }),
 
-      // Recent Contacts
-      prisma.lead.findMany({
-        take: 5,
-        orderBy: { createdAt: "desc" },
-        select: {
-          id: true,
-          firstName: true,
-          lastName: true,
-          email: true,
-          organization: true,
-          source: true,
-          createdAt: true,
+      // KPI: Upcoming bookings count
+      prisma.booking.count({
+        where: {
+          status: { in: ["CONFIRMED", "IN_PROGRESS", "PENDING"] },
+          startDate: { gte: now },
         },
+      }),
+
+      // KPI: Revenue pipeline
+      prisma.booking.aggregate({
+        _sum: { amount: true },
+        where: {
+          status: { in: ["CONFIRMED", "IN_PROGRESS"] },
+        },
+      }),
+
+      // KPI: Active leads
+      prisma.lead.count({
+        where: {
+          status: {
+            in: ["NEW", "CONTACTED", "QUALIFIED", "PROPOSAL_SENT", "NEGOTIATING"],
+          },
+        },
+      }),
+
+      // UPCOMING: Next 5 bookings
+      prisma.booking.findMany({
+        where: {
+          status: { in: ["CONFIRMED", "IN_PROGRESS", "PENDING"] },
+          startDate: { gte: now },
+        },
+        include: {
+          lead: {
+            select: {
+              firstName: true,
+              lastName: true,
+            },
+          },
+        },
+        orderBy: { startDate: "asc" },
+        take: 5,
       }),
     ])
 
     return {
-      upcomingBookingsCount,
-      revenuePipeline: revenuePipelineResult._sum.amount ?? 0,
-      outstandingBalance: outstandingBalanceResult._sum.balanceDue ?? 0,
-      activeLeadsCount,
-      nextUpBookings,
+      pendingInquiries,
       needsPrepBookings,
       paymentDueBookings,
       noCampaignBookings,
-      recentContacts,
+      upcomingBookingsCount,
+      revenuePipeline: revenuePipelineResult._sum.amount ?? 0,
+      activeLeadsCount,
+      nextUpBookings,
     }
   } catch (error) {
     console.error("Error fetching dashboard data:", error)
     return {
-      upcomingBookingsCount: 0,
-      revenuePipeline: 0,
-      outstandingBalance: 0,
-      activeLeadsCount: 0,
-      nextUpBookings: [],
+      pendingInquiries: [],
       needsPrepBookings: [],
       paymentDueBookings: [],
       noCampaignBookings: [],
-      recentContacts: [],
+      upcomingBookingsCount: 0,
+      revenuePipeline: 0,
+      activeLeadsCount: 0,
+      nextUpBookings: [],
     }
   }
 }
 
+// ─── Page ─────────────────────────────────────────────────────────
+
 export default async function DashboardPage() {
   const {
-    upcomingBookingsCount,
-    revenuePipeline,
-    outstandingBalance,
-    activeLeadsCount,
-    nextUpBookings,
+    pendingInquiries,
     needsPrepBookings,
     paymentDueBookings,
     noCampaignBookings,
-    recentContacts,
-  } = await getDashboardData()
+    upcomingBookingsCount,
+    revenuePipeline,
+    activeLeadsCount,
+    nextUpBookings,
+  } = await getTodayData()
 
-  const stats = [
-    {
-      label: "Upcoming Bookings",
-      value: upcomingBookingsCount.toString(),
-      icon: Calendar,
-      href: "/dashboard/bookings",
-    },
-    {
-      label: "Revenue Pipeline",
-      value: formatCurrency(revenuePipeline),
-      icon: TrendingUp,
-      href: "/dashboard/bookings",
-    },
-    {
-      label: "Outstanding Balance",
-      value: formatCurrency(outstandingBalance),
-      icon: DollarSign,
-      href: "/dashboard/expenses",
-    },
-    {
-      label: "Active Leads",
-      value: activeLeadsCount.toString(),
-      icon: Users,
-      href: "/dashboard/contacts",
-    },
-  ]
+  const hasActions =
+    pendingInquiries.length > 0 ||
+    needsPrepBookings.length > 0 ||
+    paymentDueBookings.length > 0 ||
+    noCampaignBookings.length > 0
 
   return (
-    <div className="space-y-8">
-      {/* Welcome Header */}
-      <div className="pt-2">
+    <div className="space-y-6">
+      {/* Header: Today + date */}
+      <div className="flex items-baseline justify-between pt-1">
         <h1
           className="text-2xl font-bold text-[#1a1a1a]"
           style={{ fontFamily: "'Space Grotesk', sans-serif" }}
         >
-          {getGreeting()}, Deke
+          Today
         </h1>
-        <p className="mt-1 text-sm text-[#666666]">{formatDate(new Date())}</p>
+        <span className="text-sm text-[#999999]">{formatTodayDate()}</span>
       </div>
 
-      {/* Row 1: KPI Cards */}
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        {stats.map((stat) => {
-          const Icon = stat.icon
-          return (
-            <Link key={stat.label} href={stat.href}>
-              <Card className="border-[#E8E4DD] bg-white transition-shadow hover:shadow-md">
-                <CardContent className="flex items-center gap-4 p-5">
-                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[#C05A3C]/10">
-                    <Icon className="h-5 w-5 text-[#C05A3C]" />
-                  </div>
-                  <div className="min-w-0">
-                    <p className="text-2xl font-bold text-[#1a1a1a]">
-                      {stat.value}
-                    </p>
-                    <p className="truncate text-xs font-medium text-[#888888]">
-                      {stat.label}
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-            </Link>
-          )
-        })}
+      {/* KPI Strip */}
+      <div className="flex items-center gap-6 text-sm text-[#999999]">
+        <Link
+          href="/dashboard/bookings"
+          className="transition-colors hover:text-[#C05A3C]"
+        >
+          {formatCurrency(revenuePipeline)} pipeline
+        </Link>
+        <span className="text-[#E8E4DD]">|</span>
+        <Link
+          href="/dashboard/bookings"
+          className="transition-colors hover:text-[#C05A3C]"
+        >
+          {upcomingBookingsCount} booking{upcomingBookingsCount !== 1 ? "s" : ""}
+        </Link>
+        <span className="text-[#E8E4DD]">|</span>
+        <Link
+          href="/dashboard/contacts"
+          className="transition-colors hover:text-[#C05A3C]"
+        >
+          {activeLeadsCount} lead{activeLeadsCount !== 1 ? "s" : ""}
+        </Link>
       </div>
 
-      {/* Row 2: Next Up */}
-      <Card className="border-[#E8E4DD] bg-white">
-        <CardHeader className="pb-3">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <CalendarDays className="h-5 w-5 text-[#C05A3C]" />
-              <CardTitle
-                className="text-lg font-bold text-[#1a1a1a]"
+      {/* Action Queue */}
+      {hasActions ? (
+        <Card className="border-[#E8E4DD] bg-white">
+          <CardContent className="p-0">
+            {/* Card header */}
+            <div className="flex items-center gap-2 border-b border-[#E8E4DD] px-5 py-3">
+              <Zap className="h-4 w-4 text-[#C05A3C]" />
+              <span
+                className="text-sm font-bold tracking-wide text-[#1a1a1a]"
                 style={{ fontFamily: "'Space Grotesk', sans-serif" }}
               >
-                Next Up
-              </CardTitle>
+                ACTION QUEUE
+              </span>
             </div>
+
+            <div className="divide-y divide-[#F0EDE8]">
+              {/* RESPOND section */}
+              {pendingInquiries.length > 0 && (
+                <ActionSection label="RESPOND">
+                  {pendingInquiries.map((inquiry) => (
+                    <ActionRow
+                      key={inquiry.id}
+                      icon={<MessageSquare className="h-4 w-4 text-[#999999]" />}
+                      description={
+                        <>
+                          {formatServiceType(inquiry.serviceType)} inquiry
+                          {" \u2014 "}
+                          {inquiry.lead.organization ||
+                            `${inquiry.lead.firstName} ${inquiry.lead.lastName}`}
+                        </>
+                      }
+                      href="/dashboard/inquiries"
+                      cta="Respond"
+                    />
+                  ))}
+                </ActionSection>
+              )}
+
+              {/* PREP section */}
+              {needsPrepBookings.length > 0 && (
+                <ActionSection label="PREP">
+                  {needsPrepBookings.map((booking) => (
+                    <ActionRow
+                      key={booking.id}
+                      icon={<Briefcase className="h-4 w-4 text-[#999999]" />}
+                      description={
+                        <>
+                          {formatServiceType(booking.serviceType)}{" "}
+                          {formatShortDate(booking.startDate)}
+                          {" \u2014 "}
+                          {booking.lead.firstName} {booking.lead.lastName}
+                        </>
+                      }
+                      href={`/dashboard/bookings/${booking.id}`}
+                      cta="Start Prep"
+                    />
+                  ))}
+                </ActionSection>
+              )}
+
+              {/* COLLECT section */}
+              {paymentDueBookings.length > 0 && (
+                <ActionSection label="COLLECT">
+                  {paymentDueBookings.map((booking) => (
+                    <ActionRow
+                      key={booking.id}
+                      icon={<DollarSign className="h-4 w-4 text-[#999999]" />}
+                      description={
+                        <>
+                          {booking.lead.firstName} {booking.lead.lastName}
+                          {" \u2014 "}
+                          {formatCurrency(booking.balanceDue ?? booking.amount ?? 0)}{" "}
+                          outstanding
+                        </>
+                      }
+                      href={`/dashboard/bookings/${booking.id}`}
+                      cta="Send Invoice"
+                    />
+                  ))}
+                </ActionSection>
+              )}
+
+              {/* GROW section */}
+              {noCampaignBookings.length > 0 && (
+                <ActionSection label="GROW">
+                  {noCampaignBookings.map((booking) => (
+                    <ActionRow
+                      key={booking.id}
+                      icon={<Rocket className="h-4 w-4 text-[#999999]" />}
+                      description={
+                        <>
+                          {formatServiceType(booking.serviceType)}{" "}
+                          {formatShortDate(booking.startDate)}
+                          {" \u2014 "}
+                          {booking.lead.firstName} {booking.lead.lastName}
+                          {booking.location ? ` (${booking.location})` : ""}
+                        </>
+                      }
+                      href={`/dashboard/bookings/${booking.id}`}
+                      cta="Find Leads"
+                    />
+                  ))}
+                </ActionSection>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="py-12 text-center">
+          <p className="text-sm text-[#999999]">
+            Nothing to do.{" "}
+            <Link
+              href="/dashboard/contacts"
+              className="text-[#C05A3C] underline underline-offset-2 hover:text-[#A84B30]"
+            >
+              Go find some gigs.
+            </Link>
+          </p>
+        </div>
+      )}
+
+      {/* Upcoming */}
+      {nextUpBookings.length > 0 && (
+        <div>
+          <div className="mb-3 flex items-center justify-between">
+            <span
+              className="text-xs font-bold uppercase tracking-wider text-[#999999]"
+              style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+            >
+              Upcoming
+            </span>
             <Link href="/dashboard/bookings">
               <Button
                 variant="ghost"
                 size="sm"
-                className="text-xs text-[#888888] hover:text-[#C05A3C]"
+                className="h-6 text-xs text-[#999999] hover:text-[#C05A3C]"
               >
-                View All Bookings
+                All Bookings
                 <ArrowRight className="ml-1 h-3 w-3" />
               </Button>
             </Link>
           </div>
-        </CardHeader>
-        <CardContent>
-          {nextUpBookings.length > 0 ? (
-            <div className="space-y-3">
-              {nextUpBookings.map((booking) => (
-                <div
-                  key={booking.id}
-                  className="flex items-center justify-between rounded-lg border border-[#E8E4DD] px-4 py-3 transition-colors hover:bg-[#FAFAF8]"
-                >
-                  <div className="flex min-w-0 flex-1 items-center gap-4">
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm font-semibold text-[#1a1a1a]">
-                          {formatServiceType(booking.serviceType)}
-                        </span>
-                        <span className="text-sm text-[#999999]">&mdash;</span>
-                        <span className="truncate text-sm text-[#666666]">
-                          {booking.lead.firstName} {booking.lead.lastName}
-                        </span>
-                      </div>
-                      <div className="mt-1 flex items-center gap-3 text-xs text-[#999999]">
-                        {booking.location && (
-                          <span className="flex items-center gap-1">
-                            <MapPin className="h-3 w-3" />
-                            {booking.location}
-                          </span>
-                        )}
-                        <span className="flex items-center gap-1">
-                          <Calendar className="h-3 w-3" />
-                          {formatShortDate(booking.startDate)}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div className="ml-4 flex shrink-0 items-center gap-2">
-                    <Badge
-                      variant="outline"
-                      className={`text-[10px] font-medium ${getPaymentStatusBadge(booking.paymentStatus)}`}
-                    >
-                      {booking.paymentStatus.replace(/_/g, " ")}
-                    </Badge>
-                    {booking.engagementStatus && (
-                      <Badge
-                        variant="outline"
-                        className={`text-[10px] font-medium ${getEngagementStatusBadge(booking.engagementStatus)}`}
-                      >
-                        {booking.engagementStatus.replace(/_/g, " ")}
-                      </Badge>
-                    )}
-                    <Link href={`/dashboard/bookings/${booking.id}`}>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="text-xs text-[#888888] hover:text-[#C05A3C]"
-                      >
-                        View
-                      </Button>
-                    </Link>
-                  </div>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className="flex items-center gap-3 rounded-lg border border-dashed border-[#D4D0C8] px-4 py-6">
-              <Calendar className="h-5 w-5 text-[#999999]" />
-              <p className="text-sm text-[#666666]">No upcoming bookings.</p>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* Row 3: Action Items + Recent Activity */}
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        {/* Action Items */}
-        <Card className="border-[#E8E4DD] bg-white">
-          <CardHeader className="pb-3">
-            <div className="flex items-center gap-2">
-              <AlertCircle className="h-5 w-5 text-[#C05A3C]" />
-              <CardTitle
-                className="text-base font-bold text-[#1a1a1a]"
-                style={{ fontFamily: "'Space Grotesk', sans-serif" }}
-              >
-                Action Items
-              </CardTitle>
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-5">
-            {/* Needs Prep */}
-            <div>
-              <div className="mb-2 flex items-center gap-2">
-                <span className="text-sm font-medium text-[#1a1a1a]">
-                  Needs Prep
-                </span>
-                <Badge
-                  variant="outline"
-                  className="border-[#E8E4DD] text-[10px] font-medium text-[#666666]"
-                >
-                  {needsPrepBookings.length}
-                </Badge>
-              </div>
-              {needsPrepBookings.length > 0 ? (
-                <div className="space-y-1.5">
-                  {needsPrepBookings.slice(0, 3).map((booking) => (
-                    <div
-                      key={booking.id}
-                      className="flex items-center justify-between rounded-md px-3 py-2 text-sm transition-colors hover:bg-[#FAFAF8]"
-                    >
-                      <span className="text-[#666666]">
-                        <span className="font-medium text-[#1a1a1a]">
-                          {formatServiceType(booking.serviceType)}
-                        </span>
-                        {" — "}
-                        {booking.lead.firstName} {booking.lead.lastName}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <div className="flex items-center gap-2 px-3 py-2">
-                  <CheckCircle2 className="h-4 w-4 text-emerald-500" />
-                  <span className="text-xs text-[#999999]">All prepped</span>
-                </div>
-              )}
-            </div>
-
-            {/* Payment Due */}
-            <div>
-              <div className="mb-2 flex items-center gap-2">
-                <span className="text-sm font-medium text-[#1a1a1a]">
-                  Payment Due
-                </span>
-                <Badge
-                  variant="outline"
-                  className="border-[#E8E4DD] text-[10px] font-medium text-[#666666]"
-                >
-                  {paymentDueBookings.length}
-                </Badge>
-              </div>
-              {paymentDueBookings.length > 0 ? (
-                <div className="space-y-1.5">
-                  {paymentDueBookings.slice(0, 3).map((booking) => (
-                    <div
-                      key={booking.id}
-                      className="flex items-center justify-between rounded-md px-3 py-2 text-sm transition-colors hover:bg-[#FAFAF8]"
-                    >
-                      <span className="text-[#666666]">
-                        {booking.lead.firstName} {booking.lead.lastName}
-                      </span>
-                      <span className="font-medium text-[#1a1a1a]">
-                        {formatCurrency(booking.amount ?? 0)}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <div className="flex items-center gap-2 px-3 py-2">
-                  <CheckCircle2 className="h-4 w-4 text-emerald-500" />
-                  <span className="text-xs text-[#999999]">All paid up</span>
-                </div>
-              )}
-            </div>
-
-            {/* No Campaign */}
-            <div>
-              <div className="mb-2 flex items-center gap-2">
-                <span className="text-sm font-medium text-[#1a1a1a]">
-                  No Campaign
-                </span>
-                <Badge
-                  variant="outline"
-                  className="border-[#E8E4DD] text-[10px] font-medium text-[#666666]"
-                >
-                  {noCampaignBookings.length}
-                </Badge>
-              </div>
-              {noCampaignBookings.length > 0 ? (
-                <div className="space-y-1.5">
-                  {noCampaignBookings.slice(0, 3).map((booking) => (
-                    <div
-                      key={booking.id}
-                      className="flex items-center justify-between rounded-md px-3 py-2 text-sm transition-colors hover:bg-[#FAFAF8]"
-                    >
-                      <span className="text-[#666666]">
-                        <span className="font-medium text-[#1a1a1a]">
-                          {formatServiceType(booking.serviceType)}
-                        </span>
-                        {" — "}
-                        {booking.lead.firstName} {booking.lead.lastName}
-                      </span>
-                      <Link href={`/dashboard/bookings/${booking.id}`}>
-                        <Button
-                          size="sm"
-                          className="h-7 bg-[#C05A3C] text-xs text-white hover:bg-[#A84B30]"
-                        >
-                          Find Nearby Leads
-                        </Button>
-                      </Link>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <div className="flex items-center gap-2 px-3 py-2">
-                  <CheckCircle2 className="h-4 w-4 text-emerald-500" />
-                  <span className="text-xs text-[#999999]">
-                    All bookings have campaigns
-                  </span>
-                </div>
-              )}
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Recent Activity */}
-        <Card className="border-[#E8E4DD] bg-white">
-          <CardHeader className="pb-3">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <Clock className="h-5 w-5 text-[#C05A3C]" />
-                <CardTitle
-                  className="text-base font-bold text-[#1a1a1a]"
-                  style={{ fontFamily: "'Space Grotesk', sans-serif" }}
-                >
-                  Recent Activity
-                </CardTitle>
-              </div>
-              <Link href="/dashboard/contacts">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="text-xs text-[#888888] hover:text-[#C05A3C]"
-                >
-                  View All
-                  <ArrowRight className="ml-1 h-3 w-3" />
-                </Button>
-              </Link>
-            </div>
-          </CardHeader>
-          <CardContent>
-            {recentContacts.length > 0 ? (
-              <div className="space-y-2">
-                {recentContacts.map((contact) => (
-                  <div
-                    key={contact.id}
-                    className="flex items-center justify-between rounded-lg px-3 py-2.5 transition-colors hover:bg-[#FAFAF8]"
+          <Card className="border-[#E8E4DD] bg-white">
+            <CardContent className="p-0">
+              <div className="divide-y divide-[#F0EDE8]">
+                {nextUpBookings.map((booking) => (
+                  <Link
+                    key={booking.id}
+                    href={`/dashboard/bookings/${booking.id}`}
+                    className="flex items-center gap-4 px-5 py-3 text-sm transition-colors hover:bg-[#FAFAF8]"
                   >
-                    <div className="min-w-0 flex-1">
-                      <p className="truncate text-sm font-medium text-[#1a1a1a]">
-                        {contact.firstName} {contact.lastName}
-                      </p>
-                      {contact.organization && (
-                        <p className="mt-0.5 truncate text-xs text-[#999999]">
-                          {contact.organization}
-                        </p>
-                      )}
-                    </div>
-                    <div className="ml-3 flex shrink-0 items-center gap-2">
-                      {contact.source && (
-                        <Badge
-                          variant="outline"
-                          className="border-[#E8E4DD] text-[10px] font-normal text-[#999999]"
-                        >
-                          {contact.source}
-                        </Badge>
-                      )}
-                      <span className="text-[10px] text-[#BBBBBB]">
-                        {formatShortDate(contact.createdAt)}
+                    <span className="w-16 shrink-0 text-[#999999]">
+                      {formatShortDate(booking.startDate)}
+                    </span>
+                    <span className="w-28 shrink-0 font-medium text-[#1a1a1a]">
+                      {formatServiceType(booking.serviceType)}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate text-[#666666]">
+                      {booking.lead.firstName} {booking.lead.lastName}
+                    </span>
+                    {booking.location && (
+                      <span className="hidden items-center gap-1 text-xs text-[#999999] sm:flex">
+                        <MapPin className="h-3 w-3" />
+                        <span className="max-w-[140px] truncate">
+                          {booking.location}
+                        </span>
                       </span>
+                    )}
+                    <div className="flex shrink-0 items-center gap-1.5">
+                      <StatusDot
+                        color={
+                          booking.paymentStatus === "PAID_IN_FULL"
+                            ? "emerald"
+                            : booking.paymentStatus === "OVERDUE"
+                              ? "red"
+                              : "amber"
+                        }
+                        label={booking.paymentStatus.replace(/_/g, " ")}
+                      />
+                      {booking.engagementStatus && (
+                        <StatusDot
+                          color={
+                            booking.engagementStatus === "READY"
+                              ? "emerald"
+                              : booking.engagementStatus === "DELIVERED"
+                                ? "sky"
+                                : "blue"
+                          }
+                          label={booking.engagementStatus.replace(/_/g, " ")}
+                        />
+                      )}
                     </div>
-                  </div>
+                  </Link>
                 ))}
               </div>
-            ) : (
-              <p className="py-4 text-center text-sm text-[#999999]">
-                No contacts yet.
-              </p>
-            )}
-          </CardContent>
-        </Card>
-      </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
     </div>
+  )
+}
+
+// ─── Sub-components ───────────────────────────────────────────────
+
+function ActionSection({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="px-5 py-3">
+      <span className="mb-2 block text-[10px] font-bold uppercase tracking-wider text-[#999999]">
+        {label}
+      </span>
+      <div className="space-y-1">{children}</div>
+    </div>
+  )
+}
+
+function ActionRow({
+  icon,
+  description,
+  href,
+  cta,
+}: {
+  icon: React.ReactNode
+  description: React.ReactNode
+  href: string
+  cta: string
+}) {
+  return (
+    <div className="flex items-center gap-3 rounded-md py-1.5">
+      <div className="shrink-0">{icon}</div>
+      <span className="min-w-0 flex-1 truncate text-sm text-[#666666]">
+        {description}
+      </span>
+      <Link href={href} className="shrink-0">
+        <Button
+          size="sm"
+          className="h-7 bg-[#C05A3C] px-3 text-xs text-white hover:bg-[#A84B30]"
+        >
+          {cta}
+          <ArrowRight className="ml-1 h-3 w-3" />
+        </Button>
+      </Link>
+    </div>
+  )
+}
+
+function StatusDot({
+  color,
+  label,
+}: {
+  color: "emerald" | "red" | "amber" | "blue" | "sky"
+  label: string
+}) {
+  const colorMap = {
+    emerald: "bg-emerald-400",
+    red: "bg-red-400",
+    amber: "bg-amber-400",
+    blue: "bg-blue-400",
+    sky: "bg-sky-400",
+  }
+
+  return (
+    <span
+      className={`inline-block h-2 w-2 rounded-full ${colorMap[color]}`}
+      title={label}
+      aria-label={label}
+    />
   )
 }

--- a/src/app/dashboard/sidebar.tsx
+++ b/src/app/dashboard/sidebar.tsx
@@ -2,15 +2,14 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useState } from "react";
 import {
-  LayoutDashboard,
+  Zap,
   Calendar,
-  Rocket,
   Users,
   CalendarDays,
   Briefcase,
   DollarSign,
-  MessageSquare,
   Package,
   Plane,
   GitBranch,
@@ -18,14 +17,12 @@ import {
 } from "lucide-react";
 
 const iconMap = {
-  LayoutDashboard,
+  Zap,
   Calendar,
-  Rocket,
   Users,
   CalendarDays,
   Briefcase,
   DollarSign,
-  MessageSquare,
   Package,
   Plane,
   GitBranch,
@@ -41,11 +38,53 @@ type NavItem = {
   badgeKey?: string;
 };
 
+function InsightButton({
+  item,
+  isActive,
+}: {
+  item: NavItem;
+  isActive: boolean;
+}) {
+  const [showTooltip, setShowTooltip] = useState(false);
+  const Icon = iconMap[item.icon];
+
+  return (
+    <Link
+      href={item.href}
+      className={`
+        relative flex h-10 w-10 items-center justify-center rounded-lg
+        transition-all duration-200
+        ${
+          isActive
+            ? "bg-[#1c1c1f] text-[#C05A3C]"
+            : "text-[#555557] hover:bg-[#1a1a1c] hover:text-[#888]"
+        }
+      `}
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
+      aria-label={item.label}
+    >
+      <Icon className="h-[18px] w-[18px]" strokeWidth={isActive ? 2.2 : 1.6} />
+
+      {showTooltip && (
+        <span
+          className="absolute left-full ml-3 whitespace-nowrap rounded-md bg-[#1c1c1f] px-2.5 py-1.5 text-[11px] font-medium tracking-[1px] text-[#CCCCCC] shadow-lg"
+          style={{ fontFamily: "var(--font-heading, 'Space Grotesk'), sans-serif" }}
+        >
+          {item.label}
+        </span>
+      )}
+    </Link>
+  );
+}
+
 export function DashboardSidebar({
-  navItems,
+  primaryNav,
+  insightNav,
   badgeCounts,
 }: {
-  navItems: NavItem[];
+  primaryNav: NavItem[];
+  insightNav: NavItem[];
   badgeCounts: BadgeCounts;
 }) {
   const pathname = usePathname();
@@ -76,10 +115,10 @@ export function DashboardSidebar({
           </Link>
         </div>
 
-        {/* Navigation */}
-        <nav className="flex-1 px-4 pt-2">
+        {/* Primary navigation */}
+        <nav className="px-4 pt-2">
           <ul className="space-y-1">
-            {navItems.map((item) => {
+            {primaryNav.map((item) => {
               const Icon = iconMap[item.icon];
               const active = isActive(item.href);
               const badgeCount = item.badgeKey ? (badgeCounts[item.badgeKey] || 0) : 0;
@@ -99,7 +138,6 @@ export function DashboardSidebar({
                     `}
                     style={{ fontFamily: "var(--font-heading, 'Space Grotesk'), sans-serif" }}
                   >
-                    {/* Active left border accent */}
                     {active && (
                       <span className="absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-r-full bg-[#C05A3C]" />
                     )}
@@ -127,7 +165,24 @@ export function DashboardSidebar({
           </ul>
         </nav>
 
-        {/* Footer version */}
+        {/* Divider */}
+        <div className="mx-7 my-5 h-px bg-[#222224]" />
+
+        {/* Insight icon grid */}
+        <div className="px-5">
+          <div className="grid grid-cols-3 gap-1.5 justify-items-center">
+            {insightNav.map((item) => (
+              <InsightButton
+                key={item.href}
+                item={item}
+                isActive={isActive(item.href)}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Spacer + footer */}
+        <div className="flex-1" />
         <div className="px-7 py-5">
           <span
             className="text-[11px] tracking-[1px] text-[#444446]"
@@ -138,10 +193,10 @@ export function DashboardSidebar({
         </div>
       </aside>
 
-      {/* Mobile bottom navigation bar */}
+      {/* Mobile bottom navigation - primary items only */}
       <nav className="fixed bottom-0 left-0 right-0 z-30 border-t border-[#222224] bg-[#111113] lg:hidden">
         <ul className="flex items-center justify-around px-2 py-2">
-          {navItems.map((item) => {
+          {primaryNav.map((item) => {
             const Icon = iconMap[item.icon];
             const active = isActive(item.href);
             const badgeCount = item.badgeKey ? (badgeCounts[item.badgeKey] || 0) : 0;
@@ -165,12 +220,9 @@ export function DashboardSidebar({
                     className="text-[9px] font-medium tracking-[0.5px]"
                     style={{ fontFamily: "var(--font-heading, 'Space Grotesk'), sans-serif" }}
                   >
-                    {item.label.length > 10
-                      ? item.label.slice(0, 7) + "..."
-                      : item.label}
+                    {item.label}
                   </span>
 
-                  {/* Active dot indicator for mobile */}
                   {active && (
                     <span className="absolute -top-0.5 left-1/2 h-[3px] w-5 -translate-x-1/2 rounded-full bg-[#C05A3C]" />
                   )}


### PR DESCRIPTION
## Summary
- **Sidebar**: 12 flat nav items → 4 primary tabs + 6 compact insight icons
- **Today page**: Read-only Command Center → action queue with CTA buttons (Respond, Start Prep, Send Invoice, Find Leads)
- **Mobile**: Bottom nav trimmed to 4 core items only

## What changed
- `layout.tsx`: Split navItems into `primaryNav` (4) and `insightNav` (6)
- `sidebar.tsx`: Primary nav + divider + icon grid with hover tooltips
- `page.tsx`: Action queue with conditional sections (empty sections hidden), compact KPI strip, upcoming bookings table with status dots

## Test plan
- [ ] Verify sidebar shows 4 primary items with correct badges
- [ ] Hover insight icons to confirm tooltips appear
- [ ] Check Today page action queue renders with real data
- [ ] Confirm CTA buttons link to correct pages
- [ ] Test mobile bottom nav shows only 4 items
- [ ] Verify all insight routes still accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)