### PR TITLE
Fix redundant locations and remove date range from event cards

### DIFF
--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -294,17 +294,11 @@ function EventCard({
               <MapPin className="h-3.5 w-3.5 shrink-0 text-[#C05A3C]" />
               <span>
                 {event.organization && event.location
-                  ? `${event.organization} — ${event.location}`
+                  ? event.location.toLowerCase().includes(event.organization.toLowerCase())
+                    ? event.location
+                    : `${event.organization} — ${event.location}`
                   : event.organization || event.location}
               </span>
-            </p>
-          )}
-
-          {/* Date range (only shown for multi-day events) */}
-          {event.startDate && event.endDate && (
-            <p className="mt-2 text-xs text-[#999]">
-              {format(event.startDate, "MMM d")} -{" "}
-              {format(event.endDate, "MMM d, yyyy")}
             </p>
           )}
 


### PR DESCRIPTION
- Skip showing organization in location line when it's already part of
  the location string (e.g. "Virginia Wesleyan" or "Palo Alto")
- Remove the date range line from calendar listings since the date badge
  already shows the date and one-day workshops were appearing as 2-day events

https://claude.ai/code/session_0171QcTp41VmNXJxtkMvFF3E