### PR TITLE
Add Singalong and Concert categories to arrangements page

### DIFF
--- a/src/app/arrangements/page.tsx
+++ b/src/app/arrangements/page.tsx
@@ -14,6 +14,8 @@ import {
   Headphones,
   Zap,
   Heart,
+  Mic,
+  Users,
 } from "lucide-react";
 
 const packages = [
@@ -105,6 +107,18 @@ const sampleCategories = [
     subtitle: "Audience favorites",
     description: "Fresh takes on beloved classics perfect for holiday performances.",
     icon: Heart,
+  },
+  {
+    title: "Singalong",
+    subtitle: "Interactive fun",
+    description: "Engaging arrangements designed to get the whole audience singing along.",
+    icon: Mic,
+  },
+  {
+    title: "Concert",
+    subtitle: "Stage ready",
+    description: "Polished arrangements crafted for powerful concert performances.",
+    icon: Users,
   },
 ];
 
@@ -330,7 +344,7 @@ export default function ArrangementsPage() {
             whileInView="animate"
             viewport={{ once: true }}
             variants={staggerContainer}
-            className="grid gap-6 md:grid-cols-3 max-w-4xl mx-auto"
+            className="grid gap-6 md:grid-cols-3 lg:grid-cols-5 max-w-6xl mx-auto"
           >
             {sampleCategories.map((category) => (
               <motion.div key={category.title} variants={fadeInUp}>


### PR DESCRIPTION
## Summary
Added two new arrangement categories (Singalong and Concert) to the arrangements page and updated the grid layout to accommodate the expanded category list.

## Key Changes
- Added two new category entries to `sampleCategories`:
  - **Singalong**: Interactive fun arrangements designed to engage audiences in singing along
  - **Concert**: Stage-ready polished arrangements for powerful concert performances
- Imported `Mic` and `Users` icons from lucide-react to represent the new categories
- Updated the category grid layout from `md:grid-cols-3` to `md:grid-cols-3 lg:grid-cols-5` to display all categories in a 5-column layout on larger screens
- Increased the max-width constraint from `max-w-4xl` to `max-w-6xl` to accommodate the wider grid

## Implementation Details
The new categories follow the existing pattern with title, subtitle, description, and icon properties. The responsive grid now displays 3 columns on medium screens and 5 columns on large screens, providing better visual distribution of the expanded category list.

https://claude.ai/code/session_01AhQX6Hybr9UZWsGCmh8gPE