### PR TITLE
Add Singalong and Concert options to booking service selection

### DIFF
--- a/src/app/arrangements/page.tsx
+++ b/src/app/arrangements/page.tsx
@@ -14,8 +14,6 @@ import {
   Headphones,
   Zap,
   Heart,
-  Mic,
-  Users,
 } from "lucide-react";
 
 const packages = [
@@ -107,18 +105,6 @@ const sampleCategories = [
     subtitle: "Audience favorites",
     description: "Fresh takes on beloved classics perfect for holiday performances.",
     icon: Heart,
-  },
-  {
-    title: "Singalong",
-    subtitle: "Interactive fun",
-    description: "Engaging arrangements designed to get the whole audience singing along.",
-    icon: Mic,
-  },
-  {
-    title: "Concert",
-    subtitle: "Stage ready",
-    description: "Polished arrangements crafted for powerful concert performances.",
-    icon: Users,
   },
 ];
 
@@ -344,7 +330,7 @@ export default function ArrangementsPage() {
             whileInView="animate"
             viewport={{ once: true }}
             variants={staggerContainer}
-            className="grid gap-6 md:grid-cols-3 lg:grid-cols-5 max-w-6xl mx-auto"
+            className="grid gap-6 md:grid-cols-3 max-w-4xl mx-auto"
           >
             {sampleCategories.map((category) => (
               <motion.div key={category.title} variants={fadeInUp}>

--- a/src/app/booking/page.tsx
+++ b/src/app/booking/page.tsx
@@ -61,6 +61,20 @@ const services = [
     price: "From $15,000",
   },
   {
+    id: "singalong",
+    icon: Sparkles,
+    title: "Singalong",
+    description: "Interactive singalong events for audiences of all ages",
+    price: "From $3,000",
+  },
+  {
+    id: "concert",
+    icon: BookOpen,
+    title: "Concert",
+    description: "Full concert performances for your venue or event",
+    price: "From $10,000",
+  },
+  {
     id: "consultation",
     icon: Clock,
     title: "Free Consultation",
@@ -169,6 +183,8 @@ function BookingContent() {
       individual: 'INDIVIDUAL_COACHING',
       workshop: 'WORKSHOP',
       speaking: 'SPEAKING',
+      singalong: 'SINGALONG',
+      concert: 'CONCERT',
       consultation: 'CONSULTATION'
     };
     return map[formId] || formId.toUpperCase();
@@ -306,6 +322,8 @@ function BookingContent() {
             </div>
           </>
         );
+      case "singalong":
+      case "concert":
       case "workshop":
       case "speaking":
         return (


### PR DESCRIPTION
Reverts the previous arrangements page change and instead adds the two new categories where they belong — as booking service options.

https://claude.ai/code/session_01AhQX6Hybr9UZWsGCmh8gPE