### PR TITLE
Fix: remove org from event location & make email optional

### DIFF
--- a/src/app/api/bookings/quick/route.ts
+++ b/src/app/api/bookings/quick/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
+import { randomUUID } from "crypto";
 import { prisma } from "@/lib/db";
 import { handleApiError, ApiError } from "@/lib/api-error";
 import { sendBookingNotification } from "@/lib/notifications/booking-notification";
@@ -10,7 +11,7 @@ const QuickBookingSchema = z.object({
   client: z.object({
     firstName: z.string().min(1, "Client first name is required"),
     lastName: z.string().min(1, "Client last name is required"),
-    email: z.string().email("Valid email is required"),
+    email: z.string().email("Valid email is required").optional().or(z.literal("")),
     organization: z.string().nullable().optional(),
     phone: z.string().nullable().optional(),
   }),
@@ -40,17 +41,19 @@ export async function POST(request: NextRequest) {
 
     const { client, serviceType, startDate, endDate, location, amount, depositPaid, notes, tripId, availabilityBefore, availabilityAfter, isPublic, publicTitle, publicDescription } = result.data;
 
+    const clientEmail = client.email || null;
+
     // Step 1: Find or create Lead
-    let lead = await prisma.lead.findUnique({
-      where: { email: client.email },
-    });
+    let lead = clientEmail
+      ? await prisma.lead.findUnique({ where: { email: clientEmail } })
+      : null;
 
     if (!lead) {
       lead = await prisma.lead.create({
         data: {
           firstName: client.firstName,
           lastName: client.lastName,
-          email: client.email,
+          email: clientEmail || `noemail-${randomUUID()}@placeholder.internal`,
           organization: client.organization || null,
           phone: client.phone || null,
           source: "direct_booking",
@@ -83,16 +86,16 @@ export async function POST(request: NextRequest) {
     }
 
     // Step 2: Find or create Contact
-    let contact = await prisma.contact.findUnique({
-      where: { email: client.email },
-    });
+    let contact = clientEmail
+      ? await prisma.contact.findUnique({ where: { email: clientEmail } })
+      : null;
 
     if (!contact) {
       contact = await prisma.contact.create({
         data: {
           firstName: client.firstName,
           lastName: client.lastName,
-          email: client.email,
+          email: clientEmail || `noemail-${randomUUID()}@placeholder.internal`,
           organization: client.organization || null,
           phone: client.phone || null,
           source: "direct_booking",

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -59,7 +59,6 @@ interface PublicEvent {
   location: string | null;
   publicTitle: string | null;
   publicDescription: string | null;
-  organization: string | null;
 }
 
 async function getUpcomingEvents(): Promise<PublicEvent[]> {
@@ -85,7 +84,6 @@ async function getUpcomingEvents(): Promise<PublicEvent[]> {
         location: true,
         publicTitle: true,
         publicDescription: true,
-        organization: true,
       },
       orderBy: {
         startDate: "asc",
@@ -102,7 +100,6 @@ async function getUpcomingEvents(): Promise<PublicEvent[]> {
       location: b.location,
       publicTitle: b.publicTitle ?? null,
       publicDescription: b.publicDescription ?? null,
-      organization: b.organization ?? null,
     }));
   } catch (error) {
     console.error("Error fetching public events:", error);
@@ -288,17 +285,11 @@ function EventCard({
             </p>
           )}
 
-          {/* Location & organization */}
-          {(event.location || event.organization) && (
+          {/* Location */}
+          {event.location && (
             <p className="flex items-center gap-1.5 text-sm text-[#666]">
               <MapPin className="h-3.5 w-3.5 shrink-0 text-[#C05A3C]" />
-              <span>
-                {event.organization && event.location
-                  ? event.location.toLowerCase().includes(event.organization.toLowerCase())
-                    ? event.location
-                    : `${event.organization} — ${event.location}`
-                  : event.organization || event.location}
-              </span>
+              <span>{event.location}</span>
             </p>
           )}
 

--- a/src/components/bookings/quick-booking-modal.tsx
+++ b/src/components/bookings/quick-booking-modal.tsx
@@ -174,14 +174,13 @@ export function QuickBookingModal({
                 />
               </div>
               <div>
-                <Label htmlFor="qb-email">Email *</Label>
+                <Label htmlFor="qb-email">Email</Label>
                 <Input
                   id="qb-email"
                   type="email"
                   placeholder="john@example.com"
                   value={form.clientEmail}
                   onChange={(e) => handleChange('clientEmail', e.target.value)}
-                  required
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- **Events page**: Removed organization from the location display on `/events`. Previously, the contact's organization was being combined with the location field (e.g. "Org Name — Location"). Now only the actual location is shown.
- **Quick booking email**: Made the email field optional in the quick booking modal and API. When no email is provided, a unique placeholder email is generated so the contact record can still be created.

## Test plan
- [ ] Visit `/events` and verify locations display without organization prefix
- [ ] Open the quick booking modal from the calendar page
- [ ] Confirm the email field no longer shows as required (no asterisk)
- [ ] Create a booking without an email — should succeed
- [ ] Create a booking with an email — should still work as before

https://claude.ai/code/session_01TsmLMgej7FC9uSrB5CUHLi