### PR TITLE
Fix: make email optional for contact/booking creation

### DIFF
--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { randomUUID } from 'crypto'
 import { prisma } from '@/lib/db'
 import { handleApiError, ApiError } from '@/lib/api-error'
 import {
@@ -13,16 +14,19 @@ export async function POST(request: NextRequest) {
     const body = await request.json()
     const validatedData: CreateContactInput = createContactSchema.parse(body)
 
-    const existingContact = await prisma.contact.findUnique({
-      where: { email: validatedData.email }
-    })
+    const contactEmail = validatedData.email || null
 
     let contact
     let isNew = false
 
+    // Only look up existing contact if a real email was provided
+    const existingContact = contactEmail
+      ? await prisma.contact.findUnique({ where: { email: contactEmail } })
+      : null
+
     if (existingContact) {
       contact = await prisma.contact.update({
-        where: { email: validatedData.email },
+        where: { email: contactEmail! },
         data: {
           firstName: validatedData.firstName,
           lastName: validatedData.lastName,
@@ -39,7 +43,7 @@ export async function POST(request: NextRequest) {
       isNew = true
       contact = await prisma.contact.create({
         data: {
-          email: validatedData.email,
+          email: contactEmail || `noemail-${randomUUID()}@placeholder.internal`,
           firstName: validatedData.firstName,
           lastName: validatedData.lastName,
           phone: validatedData.phone ?? null,

--- a/src/app/dashboard/bookings/new/page.tsx
+++ b/src/app/dashboard/bookings/new/page.tsx
@@ -345,14 +345,13 @@ function NewBookingForm() {
                       />
                     </div>
                     <div className="col-span-2 sm:col-span-1">
-                      <Label htmlFor="clientEmail">Email *</Label>
+                      <Label htmlFor="clientEmail">Email</Label>
                       <Input
                         id="clientEmail"
                         type="email"
                         placeholder="john@example.com"
                         value={form.clientEmail}
                         onChange={(e) => handleChange('clientEmail', e.target.value)}
-                        required
                         readOnly={!!selectedContactId}
                         className={selectedContactId ? 'bg-muted' : ''}
                       />

--- a/src/app/dashboard/contacts/contacts-client.tsx
+++ b/src/app/dashboard/contacts/contacts-client.tsx
@@ -753,7 +753,7 @@ export default function ContactsClient({ initialContacts }: { initialContacts: C
               </div>
             </div>
             <div>
-              <label className="text-sm font-medium mb-1 block">Email *</label>
+              <label className="text-sm font-medium mb-1 block">Email</label>
               <Input type="email" value={form.email} onChange={e => setForm(f => ({ ...f, email: e.target.value }))} />
             </div>
             <div>
@@ -788,7 +788,7 @@ export default function ContactsClient({ initialContacts }: { initialContacts: C
             <Button variant="outline" onClick={() => setIsAddOpen(false)}>Cancel</Button>
             <Button
               onClick={addContact}
-              disabled={isSubmitting || !form.firstName || !form.lastName || !form.email}
+              disabled={isSubmitting || !form.firstName || !form.lastName}
             >
               {isSubmitting ? 'Creating...' : 'Create Contact'}
             </Button>

--- a/src/components/bookings/booking-form.tsx
+++ b/src/components/bookings/booking-form.tsx
@@ -193,7 +193,7 @@ export function BookingForm({
   }, [startDateValue, form]);
 
   const handleCreateContact = async () => {
-    if (!newContact.firstName || !newContact.email) return;
+    if (!newContact.firstName) return;
 
     setCreatingContact(true);
     try {
@@ -698,7 +698,7 @@ export function BookingForm({
               </div>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="newContactEmail">Email *</Label>
+              <Label htmlFor="newContactEmail">Email</Label>
               <Input
                 id="newContactEmail"
                 type="email"
@@ -723,7 +723,7 @@ export function BookingForm({
             </Button>
             <Button
               onClick={handleCreateContact}
-              disabled={creatingContact || !newContact.firstName || !newContact.email}
+              disabled={creatingContact || !newContact.firstName}
             >
               {creatingContact ? (
                 <>

--- a/src/lib/validations/contact.ts
+++ b/src/lib/validations/contact.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 // Create contact schema
 export const createContactSchema = z.object({
-  email: z.string().email('Invalid email address'),
+  email: z.string().email('Invalid email address').optional().or(z.literal('')),
   firstName: z.string().min(1, 'First name is required'),
   lastName: z.string().min(1, 'Last name is required'),
   phone: z.string().optional().nullable(),


### PR DESCRIPTION
## Summary
- Remove organization from location display on the public events page (`/events`)
- Make email optional across **all** contact creation paths: quick booking modal, booking form "New Contact" dialog, dashboard new booking page, contacts page "Add Contact" dialog
- Update the contact validation schema and API to accept missing email, generating a unique placeholder (`noemail-{uuid}@placeholder.internal`) to satisfy the DB unique constraint

## Test plan
- [ ] Visit `/events` — location displays without organization prefix
- [ ] Dashboard > Calendar > Quick Booking — create booking without email
- [ ] Dashboard > Bookings > New > create with new contact — email not required
- [ ] Dashboard > Bookings > New (standard form) > "New Contact" button — email not required
- [ ] Dashboard > Contacts > "Add Contact" — email not required
- [ ] All paths above with email provided — still works as before

https://claude.ai/code/session_01TsmLMgej7FC9uSrB5CUHLi