### PR TITLE
Remove placeholder email generation, make email optional

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,7 +40,7 @@ model Lead {
   id            String    @id @default(cuid())
   firstName     String
   lastName      String
-  email         String    @unique
+  email         String?   @unique
   phone         String?
   organization  String?
   source        String?   // website, referral, social, etc.
@@ -85,7 +85,7 @@ model Contact {
   id            String    @id @default(cuid())
   firstName     String
   lastName      String
-  email         String    @unique
+  email         String?   @unique
   phone         String?
   organization  String?
   source        String?

--- a/src/app/api/bookings/quick/route.ts
+++ b/src/app/api/bookings/quick/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { randomUUID } from "crypto";
 import { prisma } from "@/lib/db";
 import { handleApiError, ApiError } from "@/lib/api-error";
 import { sendBookingNotification } from "@/lib/notifications/booking-notification";
@@ -53,7 +52,7 @@ export async function POST(request: NextRequest) {
         data: {
           firstName: client.firstName,
           lastName: client.lastName,
-          email: clientEmail || `noemail-${randomUUID()}@placeholder.internal`,
+          email: clientEmail,
           organization: client.organization || null,
           phone: client.phone || null,
           source: "direct_booking",
@@ -95,7 +94,7 @@ export async function POST(request: NextRequest) {
         data: {
           firstName: client.firstName,
           lastName: client.lastName,
-          email: clientEmail || `noemail-${randomUUID()}@placeholder.internal`,
+          email: clientEmail,
           organization: client.organization || null,
           phone: client.phone || null,
           source: "direct_booking",

--- a/src/app/api/campaigns/[id]/drafts/send/route.ts
+++ b/src/app/api/campaigns/[id]/drafts/send/route.ts
@@ -51,8 +51,18 @@ export async function POST(
 
     for (const draft of drafts) {
       try {
+        const leadEmail = draft.lead.email
+        if (!leadEmail) {
+          await prisma.emailDraft.update({
+            where: { id: draft.id },
+            data: { status: 'FAILED', errorMessage: 'Lead has no email address' },
+          })
+          failed++
+          continue
+        }
+
         const result = await sendEmail({
-          to: draft.lead.email,
+          to: leadEmail,
           subject: draft.subject,
           html: draft.body,
           campaignId,

--- a/src/app/api/contacts/[id]/route.ts
+++ b/src/app/api/contacts/[id]/route.ts
@@ -73,10 +73,13 @@ export async function PATCH(
       throw new ApiError(404, 'Contact not found', 'CONTACT_NOT_FOUND')
     }
 
+    // Normalize empty email to null
+    const emailValue = validatedData.email || null
+
     // If email is being changed, check it's not already taken
-    if (validatedData.email && validatedData.email !== existingContact.email) {
+    if (emailValue && emailValue !== existingContact.email) {
       const emailTaken = await prisma.contact.findUnique({
-        where: { email: validatedData.email }
+        where: { email: emailValue }
       })
       if (emailTaken) {
         throw new ApiError(409, 'A contact with this email already exists', 'EMAIL_ALREADY_EXISTS')
@@ -86,7 +89,7 @@ export async function PATCH(
     const contact = await prisma.contact.update({
       where: { id },
       data: {
-        email: validatedData.email,
+        email: emailValue,
         firstName: validatedData.firstName,
         lastName: validatedData.lastName,
         phone: validatedData.phone,

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { randomUUID } from 'crypto'
 import { prisma } from '@/lib/db'
 import { handleApiError, ApiError } from '@/lib/api-error'
 import {
@@ -43,7 +42,7 @@ export async function POST(request: NextRequest) {
       isNew = true
       contact = await prisma.contact.create({
         data: {
-          email: contactEmail || `noemail-${randomUUID()}@placeholder.internal`,
+          email: contactEmail,
           firstName: validatedData.firstName,
           lastName: validatedData.lastName,
           phone: validatedData.phone ?? null,

--- a/src/app/api/email-drafts/send/route.ts
+++ b/src/app/api/email-drafts/send/route.ts
@@ -35,8 +35,18 @@ export async function POST(request: NextRequest) {
 
     for (const draft of drafts) {
       try {
+        const leadEmail = draft.lead.email
+        if (!leadEmail) {
+          await prisma.emailDraft.update({
+            where: { id: draft.id },
+            data: { status: 'FAILED', errorMessage: 'Lead has no email address' },
+          })
+          failed++
+          continue
+        }
+
         const result = await sendEmail({
-          to: draft.lead.email,
+          to: leadEmail,
           subject: draft.subject,
           html: draft.body,
           campaignId: draft.campaignId,

--- a/src/app/api/inquiries/route.ts
+++ b/src/app/api/inquiries/route.ts
@@ -56,7 +56,7 @@ export async function POST(request: NextRequest) {
       const details = validatedData.details ? JSON.parse(validatedData.details) : {}
       sendGroupRequestNotification({
         name: `${lead.firstName} ${lead.lastName}`.trim(),
-        email: lead.email,
+        email: lead.email ?? '',
         location: details.location || lead.organization || 'Not specified',
         age: details.age ? Number(details.age) : null,
         experience: details.experience || 'Not specified',

--- a/src/app/api/leads/[id]/convert/route.ts
+++ b/src/app/api/leads/[id]/convert/route.ts
@@ -29,9 +29,12 @@ export async function POST(
     }
 
     // Check if a contact with this email already exists
-    const existingContactByEmail = await prisma.contact.findUnique({
-      where: { email: lead.email }
-    })
+    const leadEmail = lead.email
+    const existingContactByEmail = leadEmail
+      ? await prisma.contact.findUnique({
+          where: { email: leadEmail }
+        })
+      : null
 
     if (existingContactByEmail) {
       // Link the existing contact to this lead if not already linked
@@ -59,7 +62,7 @@ export async function POST(
       data: {
         firstName: lead.firstName,
         lastName: lead.lastName,
-        email: lead.email,
+        email: lead.email ?? undefined,
         phone: lead.phone,
         organization: lead.organization,
         source: lead.source,

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -97,11 +97,12 @@ export async function POST(request: NextRequest) {
           include: { lead: true },
         })
 
-        if (campaignLead) {
+        const bouncedEmail = campaignLead?.lead.email
+        if (bouncedEmail) {
           await prisma.suppression.upsert({
-            where: { email: campaignLead.lead.email },
+            where: { email: bouncedEmail },
             create: {
-              email: campaignLead.lead.email,
+              email: bouncedEmail,
               reason: 'bounce',
               source: campaignId,
             },
@@ -122,11 +123,12 @@ export async function POST(request: NextRequest) {
           include: { lead: true },
         })
 
-        if (complaintLead) {
+        const complainedEmail = complaintLead?.lead.email
+        if (complainedEmail) {
           await prisma.suppression.upsert({
-            where: { email: complaintLead.lead.email },
+            where: { email: complainedEmail },
             create: {
-              email: complaintLead.lead.email,
+              email: complainedEmail,
               reason: 'complaint',
               source: campaignId,
             },

--- a/src/app/dashboard/bookings/[id]/page.tsx
+++ b/src/app/dashboard/bookings/[id]/page.tsx
@@ -43,7 +43,7 @@ interface Booking {
     id: string;
     firstName: string;
     lastName: string;
-    email: string;
+    email: string | null;
     phone: string | null;
     organization: string | null;
   };

--- a/src/app/dashboard/bookings/new/page.tsx
+++ b/src/app/dashboard/bookings/new/page.tsx
@@ -33,7 +33,7 @@ interface Contact {
   id: string;
   firstName: string;
   lastName: string;
-  email: string;
+  email: string | null;
   organization: string | null;
   phone: string | null;
 }
@@ -102,7 +102,7 @@ function NewBookingForm() {
     setForm(prev => ({
       ...prev,
       clientName: `${contact.firstName} ${contact.lastName}`.trim(),
-      clientEmail: contact.email,
+      clientEmail: contact.email || '',
       clientOrganization: contact.organization || '',
       clientPhone: contact.phone || '',
     }));

--- a/src/app/dashboard/campaigns/[id]/page.tsx
+++ b/src/app/dashboard/campaigns/[id]/page.tsx
@@ -65,7 +65,7 @@ interface Campaign {
       id: string;
       firstName: string;
       lastName: string;
-      email: string;
+      email: string | null;
       phone: string | null;
       organization: string | null;
       contactTitle: string | null;

--- a/src/app/dashboard/contacts/contacts-client.tsx
+++ b/src/app/dashboard/contacts/contacts-client.tsx
@@ -43,7 +43,7 @@ type Contact = {
   id: string
   firstName: string
   lastName: string
-  email: string
+  email: string | null
   phone: string | null
   organization: string | null
   source: string | null
@@ -76,7 +76,7 @@ function relativeTime(date: string): string {
 function toCSV(contacts: Contact[]): string {
   const headers = ['First Name', 'Last Name', 'Email', 'Phone', 'Organization', 'Title', 'Source', 'Bookings', 'Created']
   const rows = contacts.map(c => [
-    c.firstName, c.lastName, c.email, c.phone || '', c.organization || '',
+    c.firstName, c.lastName, c.email || '', c.phone || '', c.organization || '',
     c.contactTitle || '', c.source || '', String(c._count.bookings), formatDate(c.createdAt),
   ])
   return [headers, ...rows].map(r => r.map(c => `"${c.replace(/"/g, '""')}"`).join(',')).join('\n')
@@ -136,7 +136,7 @@ export default function ContactsClient({ initialContacts }: { initialContacts: C
       const q = searchQuery.toLowerCase()
       result = result.filter(c =>
         `${c.firstName} ${c.lastName}`.toLowerCase().includes(q) ||
-        c.email.toLowerCase().includes(q) ||
+        (c.email || '').toLowerCase().includes(q) ||
         (c.organization || '').toLowerCase().includes(q) ||
         (c.contactTitle || '').toLowerCase().includes(q)
       )
@@ -269,7 +269,7 @@ export default function ContactsClient({ initialContacts }: { initialContacts: C
     setEditForm({
       firstName: detailContact.firstName,
       lastName: detailContact.lastName,
-      email: detailContact.email,
+      email: detailContact.email || '',
       phone: detailContact.phone || '',
       organization: detailContact.organization || '',
       source: detailContact.source || 'manual',
@@ -288,7 +288,7 @@ export default function ContactsClient({ initialContacts }: { initialContacts: C
         body: JSON.stringify({
           firstName: editForm.firstName,
           lastName: editForm.lastName,
-          email: editForm.email,
+          email: editForm.email || null,
           phone: editForm.phone || null,
           organization: editForm.organization || null,
           source: editForm.source,
@@ -451,7 +451,7 @@ export default function ContactsClient({ initialContacts }: { initialContacts: C
                   </TableCell>
                   {/* Email */}
                   <TableCell className="text-[#666666] max-w-[200px] truncate">
-                    {contact.email}
+                    {contact.email || '\u2014'}
                   </TableCell>
                   {/* Organization */}
                   <TableCell className="text-[#666666] hidden lg:table-cell">
@@ -719,7 +719,7 @@ export default function ContactsClient({ initialContacts }: { initialContacts: C
                 <div className="flex gap-2 pt-2">
                   <Button
                     onClick={saveEdit}
-                    disabled={isSavingEdit || !editForm.firstName || !editForm.lastName || !editForm.email}
+                    disabled={isSavingEdit || !editForm.firstName || !editForm.lastName}
                     className="flex-1"
                   >
                     {isSavingEdit ? 'Saving...' : 'Save Changes'}

--- a/src/app/dashboard/engagements/engagements-client.tsx
+++ b/src/app/dashboard/engagements/engagements-client.tsx
@@ -29,7 +29,7 @@ interface BookingLead {
   firstName: string
   lastName: string
   organization: string | null
-  email: string
+  email: string | null
 }
 
 interface SerializedBooking {
@@ -45,7 +45,7 @@ interface SerializedBooking {
   prepNotes: string | null
   deliverables: string | null
   followUpNotes: string | null
-  contact: BookingLead
+  contact: BookingLead | null
 }
 
 interface EngagementsClientProps {

--- a/src/app/dashboard/groups/page.tsx
+++ b/src/app/dashboard/groups/page.tsx
@@ -9,7 +9,7 @@ import { GroupRequestList } from '@/components/dashboard/group-request-list'
 interface GroupRequest {
   id: string
   name: string
-  email: string
+  email: string | null
   location: string
   message: string
   status: string

--- a/src/app/dashboard/inquiries/inquiries-client.tsx
+++ b/src/app/dashboard/inquiries/inquiries-client.tsx
@@ -57,7 +57,7 @@ type InquiryLead = {
   id: string
   firstName: string
   lastName: string
-  email: string
+  email: string | null
   phone: string | null
   organization: string | null
 }
@@ -163,7 +163,7 @@ export default function InquiriesClient({
       const q = searchQuery.toLowerCase()
       result = result.filter(inq =>
         `${inq.lead.firstName} ${inq.lead.lastName}`.toLowerCase().includes(q) ||
-        inq.lead.email.toLowerCase().includes(q) ||
+        (inq.lead.email || '').toLowerCase().includes(q) ||
         (inq.lead.organization || '').toLowerCase().includes(q) ||
         inq.serviceType.toLowerCase().includes(q)
       )

--- a/src/app/dashboard/leads/[id]/page.tsx
+++ b/src/app/dashboard/leads/[id]/page.tsx
@@ -13,7 +13,7 @@ interface Lead {
   id: string;
   firstName: string;
   lastName: string;
-  email: string;
+  email: string | null;
   phone: string | null;
   organization: string | null;
   source: string | null;
@@ -28,7 +28,7 @@ interface Lead {
     id: string;
     firstName: string;
     lastName: string;
-    email: string;
+    email: string | null;
   }>;
   inquiries: Array<{
     id: string;

--- a/src/app/dashboard/leads/leads-client.tsx
+++ b/src/app/dashboard/leads/leads-client.tsx
@@ -65,7 +65,7 @@ type Lead = {
   id: string
   firstName: string
   lastName: string
-  email: string
+  email: string | null
   phone: string | null
   organization: string | null
   source: string | null
@@ -99,7 +99,7 @@ function relativeTime(date: string): string {
 function toCSV(leads: Lead[]): string {
   const headers = ['First Name', 'Last Name', 'Email', 'Phone', 'Organization', 'Source', 'Status', 'Score', 'Contacts', 'Converted At', 'Created']
   const rows = leads.map(l => [
-    l.firstName, l.lastName, l.email, l.phone || '', l.organization || '',
+    l.firstName, l.lastName, l.email || '', l.phone || '', l.organization || '',
     l.source || '', l.status, String(l.score), String(l._count.contacts),
     l.convertedAt ? formatDate(l.convertedAt) : '', formatDate(l.createdAt),
   ])
@@ -157,7 +157,7 @@ export default function LeadsClient({ initialLeads }: { initialLeads: Lead[] }) 
       const q = searchQuery.toLowerCase()
       result = result.filter(l =>
         `${l.firstName} ${l.lastName}`.toLowerCase().includes(q) ||
-        l.email.toLowerCase().includes(q) ||
+        (l.email || '').toLowerCase().includes(q) ||
         (l.organization || '').toLowerCase().includes(q)
       )
     }
@@ -299,7 +299,7 @@ export default function LeadsClient({ initialLeads }: { initialLeads: Lead[] }) 
     setEditForm({
       firstName: detailLead.firstName,
       lastName: detailLead.lastName,
-      email: detailLead.email,
+      email: detailLead.email || '',
       phone: detailLead.phone || '',
       organization: detailLead.organization || '',
       source: detailLead.source || 'website',

--- a/src/app/dashboard/orders/orders-client.tsx
+++ b/src/app/dashboard/orders/orders-client.tsx
@@ -59,7 +59,7 @@ type OrderContact = {
   id: string
   firstName: string
   lastName: string
-  email: string
+  email: string | null
   phone: string | null
   organization: string | null
 }

--- a/src/components/bookings/booking-form.tsx
+++ b/src/components/bookings/booking-form.tsx
@@ -80,7 +80,7 @@ interface Contact {
   id: string;
   firstName: string;
   lastName: string;
-  email: string;
+  email: string | null;
   organization: string | null;
 }
 
@@ -309,7 +309,7 @@ export function BookingForm({
                                 <div className="flex flex-col">
                                   <span>{contact.firstName} {contact.lastName}</span>
                                   <span className="text-xs text-muted-foreground">
-                                    {contact.email}{contact.organization ? ` · ${contact.organization}` : ''}
+                                    {contact.email || ''}{contact.organization ? `${contact.email ? ' · ' : ''}${contact.organization}` : ''}
                                   </span>
                                 </div>
                               </CommandItem>

--- a/src/components/campaigns/drafts-tab.tsx
+++ b/src/components/campaigns/drafts-tab.tsx
@@ -24,7 +24,7 @@ interface Draft {
   lead: {
     firstName: string
     lastName: string
-    email: string
+    email: string | null
     organization: string | null
   }
 }

--- a/src/components/campaigns/email-draft-editor.tsx
+++ b/src/components/campaigns/email-draft-editor.tsx
@@ -26,7 +26,7 @@ interface EmailDraftEditorProps {
     lead: {
       firstName: string
       lastName: string
-      email: string
+      email: string | null
       organization: string | null
     }
   }

--- a/src/components/campaigns/leads-table-selectable.tsx
+++ b/src/components/campaigns/leads-table-selectable.tsx
@@ -32,7 +32,7 @@ interface CampaignLead {
     id: string
     firstName: string
     lastName: string
-    email: string
+    email: string | null
     phone: string | null
     organization: string | null
     contactTitle: string | null
@@ -389,7 +389,7 @@ export function LeadsTableSelectable({ leads, campaignId, onSelectionChange, onL
                         <span className="text-emerald-500 ml-1">(verified)</span>
                       )}
                     </p>
-                    {previewLead.lead.email.includes('@placeholder.local') ? (
+                    {!previewLead.lead.email || previewLead.lead.email.includes('@placeholder.local') ? (
                       <p className="text-sm text-amber-500 italic">No email found</p>
                     ) : (
                       <a

--- a/src/components/campaigns/message-card.tsx
+++ b/src/components/campaigns/message-card.tsx
@@ -16,7 +16,7 @@ interface MessageCardProps {
     respondedAt: string | null
     errorMessage: string | null
     leadName: string
-    leadEmail: string
+    leadEmail: string | null
   }
 }
 

--- a/src/components/campaigns/messages-tab.tsx
+++ b/src/components/campaigns/messages-tab.tsx
@@ -17,7 +17,7 @@ interface MessagesTabProps {
     respondedAt: string | null
     errorMessage: string | null
     leadName: string
-    leadEmail: string
+    leadEmail: string | null
   }>
 }
 

--- a/src/components/dashboard/group-request-list.tsx
+++ b/src/components/dashboard/group-request-list.tsx
@@ -14,7 +14,7 @@ import { MapPin, Mail, Music, Clock, User, Calendar } from 'lucide-react'
 interface GroupRequest {
   id: string
   name: string
-  email: string
+  email: string | null
   location: string
   message: string
   status: string

--- a/src/lib/discovery/ai-research.ts
+++ b/src/lib/discovery/ai-research.ts
@@ -20,7 +20,7 @@ interface Campaign {
 interface DiscoveredLead {
   firstName: string
   lastName: string
-  email: string
+  email: string | null
   phone: string | null
   organization: string
   source: 'AI_RESEARCH'
@@ -720,7 +720,7 @@ async function createLeadsInDatabase(leads: DiscoveredLead[]): Promise<any[]> {
     try {
       // Upsert lead (create if not exists, update if exists)
       const dbLead = await prisma.lead.upsert({
-        where: { email: lead.email },
+        where: { email: lead.email ?? undefined },
         update: {
           // Update fields that might have changed
           latitude: lead.latitude,

--- a/src/lib/discovery/deduplicator.ts
+++ b/src/lib/discovery/deduplicator.ts
@@ -6,7 +6,7 @@
  */
 
 interface Lead {
-  email: string
+  email: string | null
   score?: number
   source: string
   [key: string]: unknown
@@ -31,9 +31,14 @@ interface Lead {
  * ```
  */
 export function deduplicate<T extends Lead>(leads: T[]): T[] {
-  // Use email as the deduplication key
+  // Use email as the deduplication key; leads without email are kept as-is
+  const noEmail: T[] = []
   const byEmail = leads.reduce((acc, lead) => {
     const email = lead.email
+    if (!email) {
+      noEmail.push(lead)
+      return acc
+    }
 
     // If this email hasn't been seen, or this lead has a higher score, keep it
     if (!acc[email] || (lead.score || 0) > (acc[email].score || 0)) {
@@ -43,8 +48,8 @@ export function deduplicate<T extends Lead>(leads: T[]): T[] {
     return acc
   }, {} as Record<string, T>)
 
-  // Return all unique leads as an array
-  return Object.values(byEmail)
+  // Return all unique leads as an array, plus leads without email
+  return [...Object.values(byEmail), ...noEmail]
 }
 
 /**
@@ -78,6 +83,7 @@ export function findDuplicates(leads: Lead[]): Map<string, string[]> {
   const duplicates = new Map<string, string[]>()
 
   leads.forEach((lead) => {
+    if (!lead.email) return
     const existing = duplicates.get(lead.email) || []
     duplicates.set(lead.email, [...existing, lead.source])
   })

--- a/src/lib/discovery/draft-generator.ts
+++ b/src/lib/discovery/draft-generator.ts
@@ -108,7 +108,7 @@ Deke Sharon
     }
 
     // Skip leads that need enrichment (no usable email)
-    if (cl.lead.needsEnrichment || cl.lead.email.includes('@placeholder.local')) {
+    if (cl.lead.needsEnrichment || !cl.lead.email || cl.lead.email.includes('@placeholder.local')) {
       draftsSkipped++
       continue
     }
@@ -125,7 +125,7 @@ Deke Sharon
       organization: cl.lead.organization || '',
       contactTitle: cl.lead.contactTitle || '',
       editorialSummary: cl.lead.editorialSummary || '',
-      email: cl.lead.email,
+      email: cl.lead.email || '',
       baseLocation: campaign.baseLocation,
       availabilityDates: availabilityDates ? ` ${availabilityDates}` : ' soon',
       workshopLink,

--- a/src/lib/mappers/booking.ts
+++ b/src/lib/mappers/booking.ts
@@ -1,7 +1,7 @@
 import type { Booking, Contact, Inquiry } from '@prisma/client';
 
 type BookingWithRelations = Booking & {
-  contact: Contact;
+  contact: Contact | null;
   inquiry?: Inquiry | null;
   campaigns: Array<{
     id: string;

--- a/src/lib/mappers/campaign.ts
+++ b/src/lib/mappers/campaign.ts
@@ -12,7 +12,7 @@ type CampaignWithCount = PrismaCampaign & {
     contact: {
       firstName: string;
       lastName: string;
-    };
+    } | null;
   } | null;
 };
 

--- a/src/lib/outreach/queue.ts
+++ b/src/lib/outreach/queue.ts
@@ -52,7 +52,7 @@ export async function processOutreachQueue(
         firstName: campaignLead.lead.firstName,
         lastName: campaignLead.lead.lastName,
         organization: campaignLead.lead.organization || '',
-        email: campaignLead.lead.email,
+        email: campaignLead.lead.email || '',
         phone: campaignLead.lead.phone || '',
       })
 
@@ -60,6 +60,14 @@ export async function processOutreachQueue(
 
       // Send via appropriate channel
       if (job.channel === 'EMAIL') {
+        if (!campaignLead.lead.email) {
+          results.push({
+            success: false,
+            jobId: job.campaignLeadId,
+            error: 'Lead has no email address',
+          })
+          continue
+        }
         providerResult = await sendEmail({
           to: campaignLead.lead.email,
           subject: job.variables.subject || 'Message from Deke Sharon',

--- a/src/lib/validations/contact.ts
+++ b/src/lib/validations/contact.ts
@@ -17,7 +17,7 @@ export const createContactSchema = z.object({
 
 // Update contact schema
 export const updateContactSchema = z.object({
-  email: z.string().email('Invalid email address').optional(),
+  email: z.string().email('Invalid email address').optional().nullable().or(z.literal('')),
   firstName: z.string().min(1).optional(),
   lastName: z.string().min(1).optional(),
   phone: z.string().optional().nullable(),

--- a/verify-seed.ts
+++ b/verify-seed.ts
@@ -61,7 +61,7 @@ async function verify() {
   });
 
   futureBookings.forEach(booking => {
-    console.log(`${booking.serviceType} - ${booking.contact.organization}`);
+    console.log(`${booking.serviceType} - ${booking.contact?.organization}`);
     console.log(`  Date: ${booking.startDate?.toLocaleDateString()}, Amount: $${booking.amount}`);
     console.log(`  Location: ${booking.location}\n`);
   });


### PR DESCRIPTION
## Summary
- Removes auto-generated `noemail-{UUID}@placeholder.internal` emails that were cluttering the booking form contact dropdown
- Makes email nullable (`String?`) in Prisma schema for both Contact and Lead models
- Removes email as a required field in the contact edit form (save button no longer disabled when email is empty)
- Updates validation schema to allow null/empty email on update
- Fixes all downstream type definitions across 34 files to handle nullable email

## Test plan
- [ ] Create a contact without an email — verify no placeholder string is generated, email is stored as null
- [ ] Edit an existing contact, clear the email field, save — verify it saves successfully
- [ ] Open booking form, check contact dropdown — verify no long `noemail-...@placeholder.internal` strings appear
- [ ] Create a quick booking without client email — verify no placeholder on lead or contact
- [ ] Verify contacts with real emails still work correctly (creation, update, uniqueness check)
- [ ] Run `prisma db push` to apply schema changes to the database

https://claude.ai/code/session_01WoMdcWXzXkbtK6yybpEShv