### PR TITLE
Improve calendar usability and booking date management

### DIFF
--- a/src/app/dashboard/calendar/page.tsx
+++ b/src/app/dashboard/calendar/page.tsx
@@ -177,14 +177,19 @@ export default function CalendarPage() {
     return eachDayOfInterval({ start: calStart, end: calEnd });
   }, [currentMonth]);
 
-  // Map bookings by date string for fast lookup
+  // Map bookings by date string for fast lookup — multi-day bookings appear on every day they span
   const bookingsByDate = useMemo(() => {
     const map: Record<string, CalendarBooking[]> = {};
     for (const booking of bookings) {
       if (!booking.startDate) continue;
-      const dateKey = format(parseISO(booking.startDate), "yyyy-MM-dd");
-      if (!map[dateKey]) map[dateKey] = [];
-      map[dateKey].push(booking);
+      const start = parseISO(booking.startDate);
+      const end = booking.endDate ? parseISO(booking.endDate) : start;
+      const days = eachDayOfInterval({ start, end });
+      for (const day of days) {
+        const dateKey = format(day, "yyyy-MM-dd");
+        if (!map[dateKey]) map[dateKey] = [];
+        map[dateKey].push(booking);
+      }
     }
     return map;
   }, [bookings]);
@@ -216,24 +221,53 @@ export default function CalendarPage() {
   // Render: Booking pill
   // ------------------------------------------------------------------
 
-  function BookingPill({ booking }: { booking: CalendarBooking }) {
+  type BookingPosition = "single" | "start" | "middle" | "end";
+
+  function getBookingPosition(booking: CalendarBooking, day: Date): BookingPosition {
+    const start = parseISO(booking.startDate);
+    const end = booking.endDate ? parseISO(booking.endDate) : start;
+    if (isSameDay(start, end)) return "single";
+    if (isSameDay(day, start)) return "start";
+    if (isSameDay(day, end)) return "end";
+    return "middle";
+  }
+
+  function BookingPill({ booking, position = "single" }: { booking: CalendarBooking; position?: BookingPosition }) {
     const style = getStatusStyle(booking.status);
+
+    const roundingClass =
+      position === "single" ? "rounded" :
+      position === "start" ? "rounded-l rounded-r-none" :
+      position === "end" ? "rounded-r rounded-l-none" :
+      "rounded-none";
+
+    const isMiddle = position === "middle";
+
     return (
       <button
         onClick={(e) => {
           e.stopPropagation();
           handleBookingClick(booking.id);
         }}
-        className={`w-full truncate rounded border px-1.5 py-0.5 text-left text-[11px] font-medium leading-tight transition-opacity hover:opacity-80 ${style.bg} ${style.text} ${style.border}`}
-        title={`${serviceLabel(booking.serviceType)} - ${booking.contact?.firstName ?? 'Unknown'} ${booking.contact?.lastName ?? ''} (${booking.status})`}
+        className={`w-full truncate border px-1.5 py-0.5 text-left text-[11px] font-medium leading-tight transition-opacity hover:opacity-80 ${roundingClass} ${style.bg} ${style.text} ${style.border} ${isMiddle ? "opacity-60 border-x-0" : ""}`}
+        title={`${serviceLabel(booking.serviceType)} - ${booking.contact?.firstName ?? 'Unknown'} ${booking.contact?.lastName ?? ''} (${booking.status})${position !== "single" ? ` [${position}]` : ""}`}
         aria-label={`${serviceLabel(booking.serviceType)} with ${booking.contact?.firstName ?? 'Unknown'} ${booking.contact?.lastName ?? ''}, status ${booking.status}`}
       >
-        <span className="block truncate">
-          {serviceLabel(booking.serviceType)}
-        </span>
-        <span className="block truncate opacity-75">
-          {booking.contact?.firstName ?? 'Unknown'} {booking.contact?.lastName?.charAt(0) ?? ''}.
-        </span>
+        {position === "middle" ? (
+          <span className="block truncate text-[10px]">&nbsp;</span>
+        ) : (
+          <>
+            <span className="block truncate">
+              {position === "end" ? `\u2190 ${serviceLabel(booking.serviceType)}` : serviceLabel(booking.serviceType)}
+              {position === "start" ? " \u2192" : ""}
+            </span>
+            {position !== "end" && (
+              <span className="block truncate opacity-75">
+                {booking.contact?.firstName ?? 'Unknown'} {booking.contact?.lastName?.charAt(0) ?? ''}.
+              </span>
+            )}
+          </>
+        )}
       </button>
     );
   }
@@ -243,9 +277,11 @@ export default function CalendarPage() {
   // ------------------------------------------------------------------
 
   function ListView() {
+    // In list view, only show bookings on their start date to avoid duplication
     const daysWithBookings = calendarDays.filter((day) => {
       const key = format(day, "yyyy-MM-dd");
-      return bookingsByDate[key] && bookingsByDate[key].length > 0;
+      const dayBookings = bookingsByDate[key] || [];
+      return dayBookings.some((b) => isSameDay(parseISO(b.startDate), day));
     });
 
     if (daysWithBookings.length === 0) {
@@ -261,7 +297,9 @@ export default function CalendarPage() {
       <div className="space-y-4">
         {daysWithBookings.map((day) => {
           const key = format(day, "yyyy-MM-dd");
-          const dayBookings = bookingsByDate[key] || [];
+          const dayBookings = (bookingsByDate[key] || []).filter((b) =>
+            isSameDay(parseISO(b.startDate), day)
+          );
           return (
             <div key={key} className="rounded-lg border border-[#e5e2dc] bg-white p-4">
               <div className="mb-2 flex items-center justify-between">
@@ -289,6 +327,9 @@ export default function CalendarPage() {
               <div className="space-y-1.5">
                 {dayBookings.map((booking) => {
                   const style = getStatusStyle(booking.status);
+                  const start = parseISO(booking.startDate);
+                  const end = booking.endDate ? parseISO(booking.endDate) : start;
+                  const isMultiDay = !isSameDay(start, end);
                   return (
                     <button
                       key={booking.id}
@@ -299,17 +340,29 @@ export default function CalendarPage() {
                       <div className="min-w-0 flex-1">
                         <p className={`text-sm font-medium ${style.text}`}>
                           {serviceLabel(booking.serviceType)}
+                          {isMultiDay && (
+                            <span className="ml-2 text-[10px] font-normal opacity-70">
+                              {format(start, "MMM d")} – {format(end, "MMM d")}
+                            </span>
+                          )}
                         </p>
                         <p className="truncate text-xs text-[#666]">
                           {booking.contact?.firstName ?? 'Unknown'} {booking.contact?.lastName ?? ''}
                           {booking.location ? ` - ${booking.location}` : ""}
                         </p>
                       </div>
-                      <span
-                        className={`shrink-0 rounded px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${style.bg} ${style.text}`}
-                      >
-                        {booking.status.replace("_", " ")}
-                      </span>
+                      <div className="flex items-center gap-2 shrink-0">
+                        {isMultiDay && (
+                          <span className="rounded bg-[#1a1a1a]/10 px-1.5 py-0.5 text-[10px] font-medium text-[#666]">
+                            Multi-day
+                          </span>
+                        )}
+                        <span
+                          className={`rounded px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${style.bg} ${style.text}`}
+                        >
+                          {booking.status.replace("_", " ")}
+                        </span>
+                      </div>
                     </button>
                   );
                 })}
@@ -388,7 +441,7 @@ export default function CalendarPage() {
                 {/* Booking pills */}
                 <div className="space-y-0.5">
                   {dayBookings.slice(0, 3).map((booking) => (
-                    <BookingPill key={booking.id} booking={booking} />
+                    <BookingPill key={booking.id} booking={booking} position={getBookingPosition(booking, day)} />
                   ))}
                   {dayBookings.length > 3 && (
                     <p className="px-1 text-[10px] font-medium text-[#999]">

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from "next";
 import Link from "next/link";
 import { MapPin, Music, ArrowRight, Mic2, Calendar, Download } from "lucide-react";
-import { format, isPast } from "date-fns";
+import { format, isPast, isSameDay } from "date-fns";
 import { prisma } from "@/lib/db";
 import { generateGoogleCalendarUrl } from "@/lib/utils/ical";
 
@@ -223,6 +223,8 @@ function EventCard({
   const past = event.startDate ? isPast(event.startDate) : false;
   const accentBorder =
     SERVICE_ACCENT[event.serviceType] ?? "border-[#C05A3C]";
+  const isMultiDay =
+    event.startDate && event.endDate && !isSameDay(event.startDate, event.endDate);
 
   return (
     <div
@@ -252,22 +254,43 @@ function EventCard({
           {/* Date badge */}
           {event.startDate && (
             <div
-              className={`mb-3 inline-flex flex-col items-center rounded-md bg-[#1a1a1a] px-3 py-2 leading-none ${
+              className={`mb-3 inline-flex items-center gap-1 rounded-md bg-[#1a1a1a] px-3 py-2 leading-none ${
                 isLeft ? "sm:float-right sm:ml-4" : ""
               }`}
             >
-              <span
-                className="text-[10px] font-semibold uppercase tracking-widest text-[#C9A96E]"
-                style={{ fontFamily: "'Space Grotesk', sans-serif" }}
-              >
-                {format(event.startDate, "MMM")}
-              </span>
-              <span
-                className="text-xl font-bold text-[#F5F3EF]"
-                style={{ fontFamily: "'Space Grotesk', sans-serif" }}
-              >
-                {format(event.startDate, "d")}
-              </span>
+              <div className="flex flex-col items-center">
+                <span
+                  className="text-[10px] font-semibold uppercase tracking-widest text-[#C9A96E]"
+                  style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+                >
+                  {format(event.startDate, "MMM")}
+                </span>
+                <span
+                  className="text-xl font-bold text-[#F5F3EF]"
+                  style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+                >
+                  {format(event.startDate, "d")}
+                </span>
+              </div>
+              {isMultiDay && event.endDate && (
+                <>
+                  <span className="text-[#C9A96E]/50 text-xs font-medium px-0.5">&ndash;</span>
+                  <div className="flex flex-col items-center">
+                    <span
+                      className="text-[10px] font-semibold uppercase tracking-widest text-[#C9A96E]"
+                      style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+                    >
+                      {format(event.endDate, "MMM")}
+                    </span>
+                    <span
+                      className="text-xl font-bold text-[#F5F3EF]"
+                      style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+                    >
+                      {format(event.endDate, "d")}
+                    </span>
+                  </div>
+                </>
+              )}
             </div>
           )}
 

--- a/src/components/bookings/booking-form.tsx
+++ b/src/components/bookings/booking-form.tsx
@@ -4,12 +4,13 @@ import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { parseISO, addDays } from 'date-fns';
+import { parseISO, addDays, isSameDay } from 'date-fns';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
+import { CalendarRange, CalendarDays as CalendarDaysIcon } from 'lucide-react';
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { DatePicker } from '@/components/ui/date-picker';
 import {
@@ -179,20 +180,56 @@ export function BookingForm({
   const isPublic = form.watch('isPublic');
   const startDateValue = form.watch('startDate');
 
-  // Auto-fill end date to startDate + 1 day
+  // Detect single-day from initial values
+  const [isSingleDay, setIsSingleDay] = useState(() => {
+    if (initialValues?.startDate && initialValues?.endDate) {
+      try {
+        return isSameDay(parseISO(initialValues.startDate), parseISO(initialValues.endDate));
+      } catch {
+        return false;
+      }
+    }
+    return false;
+  });
+
+  // Auto-fill end date based on single-day toggle
   useEffect(() => {
     if (startDateValue) {
-      const currentEnd = form.getValues('endDate');
       try {
         const start = parseISO(startDateValue);
-        if (!currentEnd || parseISO(currentEnd) <= start) {
+        if (isSingleDay) {
+          form.setValue('endDate', startDateValue);
+        } else {
+          const currentEnd = form.getValues('endDate');
+          if (!currentEnd || parseISO(currentEnd) <= start) {
+            form.setValue('endDate', addDays(start, 1).toISOString());
+          }
+        }
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, [startDateValue, isSingleDay, form]);
+
+  // When toggling single-day mode, sync end date immediately
+  const handleSingleDayToggle = (checked: boolean) => {
+    setIsSingleDay(checked);
+    const currentStart = form.getValues('startDate');
+    if (currentStart) {
+      try {
+        const start = parseISO(currentStart);
+        if (checked) {
+          form.setValue('endDate', currentStart);
+        } else {
           form.setValue('endDate', addDays(start, 1).toISOString());
         }
       } catch {
         // ignore parse errors
       }
     }
-  }, [startDateValue, form]);
+  };
+
+  const parsedStartDate = startDateValue ? (() => { try { return parseISO(startDateValue); } catch { return undefined; } })() : undefined;
 
   const handleCreateContact = async () => {
     if (!newContact.firstName) return;
@@ -414,44 +451,68 @@ export function BookingForm({
         />
 
         {/* Dates */}
-        <div className="grid grid-cols-2 gap-4">
-          <FormField
-            control={form.control}
-            name="startDate"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Start Date</FormLabel>
-                <FormControl>
-                  <DatePicker
-                    value={field.value ? parseISO(field.value) : null}
-                    onChange={(date) => field.onChange(date ? date.toISOString() : '')}
-                    enableTime
-                    placeholder="Select start date"
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <FormLabel className="text-sm font-medium">Event Dates</FormLabel>
+            <div className="flex items-center gap-2">
+              {isSingleDay ? (
+                <CalendarDaysIcon className="h-3.5 w-3.5 text-muted-foreground" />
+              ) : (
+                <CalendarRange className="h-3.5 w-3.5 text-muted-foreground" />
+              )}
+              <span className="text-xs text-muted-foreground">
+                {isSingleDay ? 'Single day' : 'Multi-day'}
+              </span>
+              <Switch
+                checked={isSingleDay}
+                onCheckedChange={handleSingleDayToggle}
+                aria-label="Toggle single day event"
+              />
+            </div>
+          </div>
 
-          <FormField
-            control={form.control}
-            name="endDate"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>End Date</FormLabel>
-                <FormControl>
-                  <DatePicker
-                    value={field.value ? parseISO(field.value) : null}
-                    onChange={(date) => field.onChange(date ? date.toISOString() : '')}
-                    enableTime
-                    placeholder="Select end date"
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
+          <div className={`grid gap-4 ${isSingleDay ? 'grid-cols-1' : 'grid-cols-2'}`}>
+            <FormField
+              control={form.control}
+              name="startDate"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{isSingleDay ? 'Date' : 'Start Date'}</FormLabel>
+                  <FormControl>
+                    <DatePicker
+                      value={field.value ? parseISO(field.value) : null}
+                      onChange={(date) => field.onChange(date ? date.toISOString() : '')}
+                      enableTime
+                      placeholder={isSingleDay ? 'Select date' : 'Select start date'}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {!isSingleDay && (
+              <FormField
+                control={form.control}
+                name="endDate"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>End Date</FormLabel>
+                    <FormControl>
+                      <DatePicker
+                        value={field.value ? parseISO(field.value) : null}
+                        onChange={(date) => field.onChange(date ? date.toISOString() : '')}
+                        enableTime
+                        placeholder="Select end date"
+                        defaultMonth={parsedStartDate}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
             )}
-          />
+          </div>
         </div>
 
         {/* Location & Timezone */}

--- a/src/components/bookings/quick-booking-modal.tsx
+++ b/src/components/bookings/quick-booking-modal.tsx
@@ -9,7 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { DatePicker } from '@/components/ui/date-picker';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
-import { Loader2, Save, CheckCircle2, Globe } from 'lucide-react';
+import { Loader2, Save, CheckCircle2, Globe, CalendarRange, CalendarDays as CalendarDaysIcon } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -48,6 +48,8 @@ export function QuickBookingModal({
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
 
+  const [isSingleDay, setIsSingleDay] = useState(false);
+
   const [form, setForm] = useState({
     clientName: '',
     clientEmail: '',
@@ -65,6 +67,7 @@ export function QuickBookingModal({
   // Reset form when modal opens with a new date
   const handleOpenChange = (isOpen: boolean) => {
     if (isOpen) {
+      setIsSingleDay(false);
       setForm({
         clientName: '',
         clientEmail: '',
@@ -82,6 +85,16 @@ export function QuickBookingModal({
       setSuccess(false);
     }
     onOpenChange(isOpen);
+  };
+
+  const handleSingleDayToggle = (checked: boolean) => {
+    setIsSingleDay(checked);
+    if (checked && form.startDate) {
+      setForm(prev => ({ ...prev, endDate: prev.startDate }));
+    } else if (!checked && form.startDate) {
+      const start = parseISO(form.startDate);
+      setForm(prev => ({ ...prev, endDate: addDays(start, 1).toISOString() }));
+    }
   };
 
   const handleChange = (field: string, value: string | boolean) => {
@@ -213,34 +226,60 @@ export function QuickBookingModal({
             </div>
 
             {/* Scheduling */}
-            <div className="grid grid-cols-2 gap-3">
-              <div className="space-y-1.5">
-                <Label>Start Date</Label>
-                <DatePicker
-                  value={form.startDate ? parseISO(form.startDate) : null}
-                  onChange={(date) => {
-                    const iso = date ? date.toISOString() : '';
-                    handleChange('startDate', iso);
-                    // Auto-fill end date to +1 day
-                    if (date) {
-                      const currentEnd = form.endDate ? parseISO(form.endDate) : null;
-                      if (!currentEnd || currentEnd <= date) {
-                        handleChange('endDate', addDays(date, 1).toISOString());
-                      }
-                    }
-                  }}
-                  enableTime
-                  placeholder="Start date"
-                />
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <Label className="text-sm font-medium">Dates</Label>
+                <div className="flex items-center gap-2">
+                  {isSingleDay ? (
+                    <CalendarDaysIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                  ) : (
+                    <CalendarRange className="h-3.5 w-3.5 text-muted-foreground" />
+                  )}
+                  <span className="text-xs text-muted-foreground">
+                    {isSingleDay ? 'Single day' : 'Multi-day'}
+                  </span>
+                  <Switch
+                    checked={isSingleDay}
+                    onCheckedChange={handleSingleDayToggle}
+                    aria-label="Toggle single day event"
+                  />
+                </div>
               </div>
-              <div className="space-y-1.5">
-                <Label>End Date</Label>
-                <DatePicker
-                  value={form.endDate ? parseISO(form.endDate) : null}
-                  onChange={(date) => handleChange('endDate', date ? date.toISOString() : '')}
-                  enableTime
-                  placeholder="End date"
-                />
+              <div className={`grid gap-3 ${isSingleDay ? 'grid-cols-1' : 'grid-cols-2'}`}>
+                <div className="space-y-1.5">
+                  <Label>{isSingleDay ? 'Date' : 'Start Date'}</Label>
+                  <DatePicker
+                    value={form.startDate ? parseISO(form.startDate) : null}
+                    onChange={(date) => {
+                      const iso = date ? date.toISOString() : '';
+                      handleChange('startDate', iso);
+                      if (date) {
+                        if (isSingleDay) {
+                          handleChange('endDate', iso);
+                        } else {
+                          const currentEnd = form.endDate ? parseISO(form.endDate) : null;
+                          if (!currentEnd || currentEnd <= date) {
+                            handleChange('endDate', addDays(date, 1).toISOString());
+                          }
+                        }
+                      }
+                    }}
+                    enableTime
+                    placeholder={isSingleDay ? 'Select date' : 'Start date'}
+                  />
+                </div>
+                {!isSingleDay && (
+                  <div className="space-y-1.5">
+                    <Label>End Date</Label>
+                    <DatePicker
+                      value={form.endDate ? parseISO(form.endDate) : null}
+                      onChange={(date) => handleChange('endDate', date ? date.toISOString() : '')}
+                      enableTime
+                      placeholder="End date"
+                      defaultMonth={form.startDate ? parseISO(form.startDate) : undefined}
+                    />
+                  </div>
+                )}
               </div>
             </div>
 

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -16,20 +16,20 @@ function Calendar({
   return (
     <DayPicker
       showOutsideDays={showOutsideDays}
-      className={cn("p-3", className)}
+      className={cn("p-3 px-5", className)}
       classNames={{
         months: "flex flex-col sm:flex-row gap-2",
         month: "flex flex-col gap-4",
-        month_caption: "flex justify-center pt-1 relative items-center w-full",
+        month_caption: "flex justify-center pt-1 relative items-center w-full px-10",
         caption_label: "text-sm font-medium",
         nav: "flex items-center gap-1",
         button_previous: cn(
           buttonVariants({ variant: "outline" }),
-          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute left-1"
+          "h-9 w-9 bg-transparent p-0 opacity-50 hover:opacity-100 absolute -left-1"
         ),
         button_next: cn(
           buttonVariants({ variant: "outline" }),
-          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute right-1"
+          "h-9 w-9 bg-transparent p-0 opacity-50 hover:opacity-100 absolute -right-1"
         ),
         month_grid: "w-full border-collapse space-x-1",
         weekdays: "flex",
@@ -59,7 +59,7 @@ function Calendar({
       components={{
         Chevron: ({ orientation }) => {
           const Icon = orientation === "left" ? ChevronLeft : ChevronRight
-          return <Icon className="h-4 w-4" />
+          return <Icon className="h-5 w-5" />
         },
       }}
       {...props}

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -15,6 +15,8 @@ interface DatePickerProps {
   placeholder?: string
   enableTime?: boolean
   disabled?: boolean
+  /** Month to show when the calendar opens (falls back to value, then today) */
+  defaultMonth?: Date
 }
 
 export function DatePicker({
@@ -23,9 +25,11 @@ export function DatePicker({
   placeholder = "Pick a date",
   enableTime = false,
   disabled = false,
+  defaultMonth,
 }: DatePickerProps) {
   const [showTime, setShowTime] = React.useState(false)
   const [open, setOpen] = React.useState(false)
+  const [calendarMonth, setCalendarMonth] = React.useState<Date>(new Date())
 
   // Parse value to Date
   const date = React.useMemo(() => {
@@ -48,6 +52,14 @@ export function DatePicker({
       }
     }
   }, []) // only on mount
+
+  // Reset calendar month when popover opens
+  const handleOpenChange = (isOpen: boolean) => {
+    if (isOpen) {
+      setCalendarMonth(defaultMonth ?? date ?? new Date())
+    }
+    setOpen(isOpen)
+  }
 
   const hours = date ? date.getHours() : 9
   const minutes = date ? date.getMinutes() : 0
@@ -122,7 +134,7 @@ export function DatePicker({
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button
           type="button"
@@ -142,6 +154,8 @@ export function DatePicker({
           mode="single"
           selected={date}
           onSelect={handleDateSelect}
+          month={calendarMonth}
+          onMonthChange={setCalendarMonth}
           initialFocus
         />
 


### PR DESCRIPTION
- Enlarge calendar nav arrows (h-9 w-9) and pull them away from day numbers
  to prevent misclicks when navigating months
- Add smart month opening: date picker opens to the selected date's month
  instead of always defaulting to today, using controlled month state
- Add defaultMonth prop to DatePicker so end date picker opens to start
  date's month when booking months ahead
- Add single-day vs multi-day toggle to booking form and quick booking modal
  with automatic end date sync (single-day sets endDate = startDate)
- Display multi-day bookings across all spanned days on the master calendar
  with positional styling (start/middle/end pills with directional arrows)
- Show date range badge on public events page for multi-day events
- Show date range and multi-day label in calendar list view

https://claude.ai/code/session_01FHtk41VhrRLuLNqRxT5Fx3