### PR TITLE
Refactor event card layout with overlapping design

### DIFF
--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -167,7 +167,7 @@ export default async function EventsPage() {
                 aria-hidden="true"
               />
 
-              <div className="space-y-12 sm:space-y-16">
+              <div>
                 {events.map((event, index) => (
                   <EventCard
                     key={event.id}
@@ -228,7 +228,8 @@ function EventCard({
 
   return (
     <div
-      className={`relative flex ${past ? "opacity-60" : ""}`}
+      className={`relative flex mt-8 sm:-mt-24 sm:first:mt-0 ${past ? "opacity-60" : ""}`}
+      style={{ zIndex: index + 1 }}
       role="article"
       aria-label={`${serviceLabel(event.serviceType)}${event.location ? ` in ${event.location}` : ""}`}
     >


### PR DESCRIPTION
## Summary
Updated the events page layout to implement an overlapping card design pattern, replacing the uniform spacing with negative margins and z-index layering for a more dynamic visual presentation.

## Key Changes
- Removed `space-y-12 sm:space-y-16` spacing utility from the events container to allow custom spacing control
- Updated `EventCard` component styling:
  - Added `mt-8 sm:-mt-24 sm:first:mt-0` margins to create overlapping effect on larger screens
  - Added dynamic `zIndex` based on card index to ensure proper layering of overlapped cards
  - Maintained existing opacity styling for past events

## Implementation Details
The overlapping layout uses negative margins on small screens (`sm:-mt-24`) to create a cascading visual effect while the `first:mt-0` ensures the first card has no negative margin. The z-index is dynamically set based on the card's position in the array to maintain proper stacking order when cards overlap.

https://claude.ai/code/session_01SkxMicMhawho3BBa9fdXSA