### PR TITLE
Adjust EventCard negative margin on small screens

### DIFF
--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -228,7 +228,7 @@ function EventCard({
 
   return (
     <div
-      className={`relative flex mt-8 sm:-mt-24 sm:first:mt-0 ${past ? "opacity-60" : ""}`}
+      className={`relative flex mt-8 sm:-mt-12 sm:first:mt-0 ${past ? "opacity-60" : ""}`}
       style={{ zIndex: index + 1 }}
       role="article"
       aria-label={`${serviceLabel(event.serviceType)}${event.location ? ` in ${event.location}` : ""}`}


### PR DESCRIPTION
## Summary
Reduced the negative top margin applied to EventCard components on small screens to improve spacing and layout consistency.

## Changes
- Modified the `sm:-mt-24` Tailwind class to `sm:-mt-12` on the EventCard container, reducing the negative margin from -6rem to -3rem on small screens and above
- This adjustment affects the vertical spacing of event cards in the events listing, particularly for non-first cards which previously had excessive negative margin overlap

## Details
The EventCard component uses a negative margin technique to create an overlapping card effect on small screens. The previous `-mt-24` value was creating too much overlap. The new `-mt-12` value provides a more balanced visual spacing while maintaining the stacked card aesthetic.

https://claude.ai/code/session_01RknNBSCBzZSpFK3XX8QfCG