### PR TITLE
Disable autocomplete on date and time input fields

### DIFF
--- a/src/app/dashboard/trips/new/page.tsx
+++ b/src/app/dashboard/trips/new/page.tsx
@@ -104,6 +104,7 @@ export default function NewTripPage() {
                     name="startDate"
                     type="date"
                     required
+                    autoComplete="off"
                     disabled={isSubmitting}
                   />
                 </div>
@@ -114,6 +115,7 @@ export default function NewTripPage() {
                     name="endDate"
                     type="date"
                     required
+                    autoComplete="off"
                     disabled={isSubmitting}
                   />
                 </div>

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -170,6 +170,7 @@ export function DatePicker({
                   max={12}
                   value={displayHour}
                   onChange={handleHourChange}
+                  autoComplete="off"
                   className="w-12 rounded-md border bg-transparent px-2 py-1 text-sm text-center focus:outline-none focus:ring-2 focus:ring-ring"
                   aria-label="Hour"
                 />
@@ -180,6 +181,7 @@ export function DatePicker({
                   max={59}
                   value={minutes.toString().padStart(2, "0")}
                   onChange={handleMinuteChange}
+                  autoComplete="off"
                   className="w-12 rounded-md border bg-transparent px-2 py-1 text-sm text-center focus:outline-none focus:ring-2 focus:ring-ring"
                   aria-label="Minute"
                 />


### PR DESCRIPTION
## Summary
This PR adds `autoComplete="off"` attributes to date and time input fields across the application to prevent browser autocomplete behavior on these specialized input controls.

## Key Changes
- Added `autoComplete="off"` to the start date and end date inputs in the new trip page (`src/app/dashboard/trips/new/page.tsx`)
- Added `autoComplete="off"` to the hour and minute inputs in the DatePicker component (`src/components/ui/date-picker.tsx`)

## Implementation Details
The autocomplete attribute is being disabled on these inputs to prevent browser autocomplete suggestions from interfering with the date and time selection experience. This is particularly important for:
- Native date inputs which may have inconsistent autocomplete behavior across browsers
- Custom time picker inputs (hour/minute spinners) where autocomplete suggestions would be inappropriate and disruptive to the user experience

https://claude.ai/code/session_01VwrxHvofcmcbfPPjyTQLfr