### PR TITLE
Add reply-to email address to signup notifications

### DIFF
--- a/src/lib/notifications/signup-notification.ts
+++ b/src/lib/notifications/signup-notification.ts
@@ -142,6 +142,7 @@ export async function sendSignupNotification(
     const result = await resend.emails.send({
       from: fromEmail,
       to: NOTIFICATION_EMAILS,
+      replyTo: data.email,
       subject: `${config.emoji} ${config.label}: ${data.name} — ${data.email}`,
       html: generateAdminEmailHtml(data),
       tags: [


### PR DESCRIPTION
## Summary
Added the ability to reply directly to signup notification emails by setting the `replyTo` field to the email address of the person who signed up.

## Changes
- Added `replyTo: data.email` to the email configuration in `sendSignupNotification()`
- This allows admins receiving signup notifications to reply directly to the user who signed up, improving the notification workflow

## Implementation Details
The `replyTo` field is set to the email address from the signup form data, enabling direct communication with new signups without requiring manual email copying.

https://claude.ai/code/session_017AZXYQzaQ3G36nruh1Rboz