### PR TITLE
Filter college + classical orgs from ALL sources, clean org names

### DIFF
--- a/src/lib/discovery/firecrawl-research.ts
+++ b/src/lib/discovery/firecrawl-research.ts
@@ -414,6 +414,18 @@ function extractOrgName(title: string): string {
     .replace(/\s*[-–—|]\s*Safe Space Alliance$/i, '')
     .trim()
 
+  // Strip descriptions after colons: "Overboard: Boston a cappella group..." → "Overboard"
+  // Only if what's before the colon looks like a name (3+ chars) and what's after is descriptive
+  if (name.includes(':')) {
+    const beforeColon = name.split(':')[0].trim()
+    const afterColon = name.split(':').slice(1).join(':').trim().toLowerCase()
+    const descriptiveWords = ['boston', 'new york', 'group', 'singing', 'a cappella', 'vocal', 'pop', 'rock', 'jazz', 'contemporary', 'community', 'greater', 'performing']
+    const isDescriptive = descriptiveWords.some(w => afterColon.includes(w))
+    if (beforeColon.length >= 3 && isDescriptive) {
+      name = beforeColon
+    }
+  }
+
   // Remove leading "Home —", "Welcome to ", "About —" etc.
   name = name
     .replace(/^(?:Home|Welcome|About|Contact)\s*[-–—|:]\s*/i, '')

--- a/src/lib/discovery/orchestrator.ts
+++ b/src/lib/discovery/orchestrator.ts
@@ -241,7 +241,41 @@ export async function discoverLeads(campaignId: string): Promise<DiscoveryResult
   }
 
   // Merge all leads (Perplexity + Firecrawl both contribute to AI_RESEARCH)
-  const allLeads = [...pastClients, ...dormant, ...similar, ...aiResearch, ...perplexity]
+  const rawLeads = [...pastClients, ...dormant, ...similar, ...aiResearch, ...perplexity]
+
+  // Filter out college/university and classical groups from ALL sources
+  const allLeads = rawLeads.filter((lead: any) => {
+    const org = (lead.organization || '').toLowerCase()
+
+    // College/university groups
+    const collegePatterns = [
+      'berklee', 'college of music', 'university', ' college',
+      'conservatory', 'institute of', 'endicott ensembles',
+    ]
+    if (collegePatterns.some(p => org.includes(p))) {
+      console.log(`[Discovery:Orchestrator] Filtered college/university group: "${lead.organization}"`)
+      return false
+    }
+
+    // Classical/choral society orgs (without contemporary signals)
+    const classicalPatterns = ['choral international', 'choral society', 'symphony', 'orchestra', 'opera', 'philharmonic']
+    const contemporarySignals = ['a cappella', 'pop', 'rock', 'jazz', 'barbershop', 'contemporary']
+    const isClassical = classicalPatterns.some(p => org.includes(p))
+    const hasContemporary = contemporarySignals.some(p => org.includes(p))
+    if (isClassical && !hasContemporary) {
+      console.log(`[Discovery:Orchestrator] Filtered classical group: "${lead.organization}"`)
+      return false
+    }
+
+    return true
+  })
+
+  if (rawLeads.length > allLeads.length) {
+    const filtered = rawLeads.length - allLeads.length
+    console.log(`[Discovery:Orchestrator] Org type filter removed ${filtered} college/classical leads`)
+    warnings.push(`${filtered} leads filtered out (college/university or classical)`)
+  }
+
   const originalCount = allLeads.length
 
   // Deduplicate by email (keeping highest score per email)

--- a/src/lib/discovery/perplexity-research.ts
+++ b/src/lib/discovery/perplexity-research.ts
@@ -64,13 +64,21 @@ function cleanOrgName(name: string): string {
     .replace(/\s*[-–—]\s*(singing|group|performing|booking|contemporary|events|calendar).*$/i, '')
     .trim()
 
-  // If a colon remains, take only what's after it (often "Concert Series: Real Group Name")
+  // Handle colons — "Overboard: Boston a cappella group..." → "Overboard"
   if (cleaned.includes(':')) {
-    const parts = cleaned.split(':')
-    const afterColon = parts[parts.length - 1].trim()
-    // Use the after-colon part only if it looks substantial
-    if (afterColon.length >= 5) {
-      cleaned = afterColon
+    const beforeColon = cleaned.split(':')[0].trim()
+    const afterColon = cleaned.split(':').slice(1).join(':').trim().toLowerCase()
+    // If after the colon is descriptive text (city names, genre words), keep only before
+    const descriptiveWords = ['boston', 'new york', 'group', 'singing', 'a cappella', 'vocal', 'pop', 'rock', 'jazz', 'contemporary', 'community', 'greater', 'performing']
+    const isDescriptive = descriptiveWords.some(w => afterColon.includes(w))
+    if (beforeColon.length >= 3 && isDescriptive) {
+      cleaned = beforeColon
+    } else {
+      // Otherwise take the after-colon part (e.g. "Concert Series: Real Group Name")
+      const after = cleaned.split(':').slice(1).join(':').trim()
+      if (after.length >= 5) {
+        cleaned = after
+      }
     }
   }
 
@@ -105,13 +113,20 @@ function isValidOrgName(name: string): boolean {
   ]
   if (searchTermPatterns.some(p => p.test(name))) return false
 
-  // Reject college/university affiliated groups (org name contains institution)
+  // Reject college/university affiliated groups
   const collegePatterns = [
     'berklee', 'college of music', 'university', 'college',
     'school of music', 'conservatory', 'institute',
     'endicott ensembles', 'campus',
   ]
   if (collegePatterns.some(p => lower.includes(p))) return false
+
+  // Reject classical/choral society orgs
+  const classicalPatterns = [
+    'choral international', 'choral society', 'symphony',
+    'orchestra', 'opera', 'philharmonic', 'chamber choir',
+  ]
+  if (classicalPatterns.some(p => lower.includes(p))) return false
 
   // Reject if it looks like a person's name (2 words, both capitalized, no org keywords)
   const words = name.split(/\s+/)


### PR DESCRIPTION
## Summary

- **Orchestrator-level filter**: Rejects college/university and classical orgs from ALL discovery sources (including Similar Orgs which was bypassing the per-source filters)
- **Fix colon descriptions**: "Overboard: Boston a cappella group singing contemporary pop/rock" → "Overboard"
- **Add classical patterns**: choral international, symphony, philharmonic etc. rejected by Perplexity validator

https://claude.ai/code/session_019zv7k9ssVntZj57CUexzNa