### PR TITLE
Fix enrichment: plain HTTP scraper, no Firecrawl dependency

### DIFF
--- a/src/lib/discovery/perplexity-research.ts
+++ b/src/lib/discovery/perplexity-research.ts
@@ -55,6 +55,8 @@ interface DiscoveredLead {
 interface PerplexityOrg {
   name: string
   website: string | null
+  email: string | null
+  contactName: string | null
   description: string | null
 }
 
@@ -145,20 +147,22 @@ function buildPrompts(campaign: Campaign): string[] {
     : campaign.baseLocation
   const radius = campaign.radius
 
-  const nameRules = `IMPORTANT: Return ONLY the group's official name (e.g. "Vocal Revolution", "The Nor'easters", "Boston Skyline Chorus"). Include the group's website URL. Do NOT include page titles, descriptions, or taglines in the name field.`
+  const nameRules = `IMPORTANT: Return ONLY the group's official name (e.g. "Vocal Revolution", "The Nor'easters", "Boston Skyline Chorus"). Do NOT include page titles, descriptions, or taglines in the name field.`
+  const contactRules = `Include the group's website URL and contact email if you can find it. For the contact email, look for the music director's email, group contact email, or info@ email from their website.`
+  const jsonFormat = `Return as JSON array: [{"name": "...", "website": "...", "email": "...", "contactName": "..."}]. If you can't find an email or contact name, use null for those fields.`
 
   return [
     // Segment 1: College a cappella — Deke's core market
-    `List college and university a cappella groups within ${radius} miles of ${location}. Include groups from all nearby colleges and universities — there are typically many groups per school. These groups hire coaches, arrangers, and workshop leaders. ${nameRules} Return as JSON array: [{"name": "...", "website": "..."}]. Be thorough — list at least 15-20 groups.`,
+    `List college and university a cappella groups within ${radius} miles of ${location}. Include groups from all nearby colleges and universities — there are typically many groups per school. These groups hire coaches, arrangers, and workshop leaders. ${nameRules} ${contactRules} ${jsonFormat} Be thorough — list at least 15-20 groups.`,
 
     // Segment 2: Community/semi-pro a cappella
-    `List community a cappella groups, post-collegiate a cappella groups, and semi-professional vocal ensembles within ${radius} miles of ${location}. Include groups that perform pop, rock, jazz, R&B, or contemporary arrangements. ${nameRules} Return as JSON array: [{"name": "...", "website": "..."}]. List at least 10-15 groups.`,
+    `List community a cappella groups, post-collegiate a cappella groups, and semi-professional vocal ensembles within ${radius} miles of ${location}. Include groups that perform pop, rock, jazz, R&B, or contemporary arrangements. ${nameRules} ${contactRules} ${jsonFormat} List at least 10-15 groups.`,
 
     // Segment 3: Barbershop / Sweet Adelines / Harmony Inc
-    `List barbershop choruses (BHS chapters), barbershop quartets, Sweet Adelines chapters, and Harmony Inc chapters within ${radius} miles of ${location}. Check the Barbershop Harmony Society Northeastern District, Sweet Adelines Region 1, and Harmony Inc directories. ${nameRules} Return as JSON array: [{"name": "...", "website": "..."}]. List at least 10-15 groups.`,
+    `List barbershop choruses (BHS chapters), barbershop quartets, Sweet Adelines chapters, and Harmony Inc chapters within ${radius} miles of ${location}. Check the Barbershop Harmony Society Northeastern District, Sweet Adelines Region 1, and Harmony Inc directories. ${nameRules} ${contactRules} ${jsonFormat} List at least 10-15 groups.`,
 
     // Segment 4: Contemporary choruses + festivals
-    `List community choruses and choirs within ${radius} miles of ${location} that perform contemporary, pop, jazz, gospel, or show music (not exclusively classical). Also list any a cappella festivals, vocal competitions, or singing conventions in the area. ${nameRules} Return as JSON array: [{"name": "...", "website": "..."}]. List at least 10 groups.`,
+    `List community choruses and choirs within ${radius} miles of ${location} that perform contemporary, pop, jazz, gospel, or show music (not exclusively classical). Also list any a cappella festivals, vocal competitions, or singing conventions in the area. ${nameRules} ${contactRules} ${jsonFormat} List at least 10 groups.`,
   ]
 }
 
@@ -222,6 +226,8 @@ function parseOrgs(responseText: string): PerplexityOrg[] {
       .map((item: any) => ({
         name: cleanOrgName(item.name.trim()),
         website: item.website?.trim() || item.url?.trim() || null,
+        email: item.email?.trim() || null,
+        contactName: item.contactName?.trim() || item.contact_name?.trim() || null,
         description: item.description?.trim() || null,
       }))
       .filter((item: PerplexityOrg) => isValidOrgName(item.name))
@@ -309,52 +315,93 @@ export async function discoverWithPerplexity(campaign: Campaign): Promise<AIRese
 
   const leads: DiscoveredLead[] = []
 
+  // Third-party SaaS email domains to skip
+  const thirdPartyDomains = [
+    'mymusicstaff.com', 'groupanizer.com', 'placeholder.local',
+    'wixpress.com', 'squarespace.com', 'wordpress.com',
+    'mailchimp.com', 'constantcontact.com',
+  ]
+
   for (const org of candidates) {
     try {
-      if (!org.website) {
-        console.log(`[Perplexity Research] No website for "${org.name}" — skipping`)
+      let email: string | null = null
+      let firstName = 'Contact'
+      let lastName = `at ${org.name}`
+      let contactTitle: string | null = null
+      let enrichmentSource: string | null = null
+      let emailVerified = false
+      let phone: string | null = null
+
+      // Step 1: Use Perplexity-provided email if available (free, no scraping)
+      if (org.email && org.email.includes('@')) {
+        const emailDomain = org.email.split('@')[1]?.toLowerCase() || ''
+        if (!thirdPartyDomains.some(d => emailDomain.includes(d))) {
+          email = org.email.toLowerCase()
+          enrichmentSource = 'perplexity'
+          emailVerified = false // Not verified, came from AI
+
+          if (org.contactName) {
+            const nameParts = org.contactName.split(' ')
+            if (nameParts.length >= 2) {
+              firstName = nameParts[0]
+              lastName = nameParts.slice(1).join(' ')
+            } else if (nameParts.length === 1) {
+              firstName = nameParts[0]
+            }
+          }
+          console.log(`[Perplexity Research] Using Perplexity-provided email for "${org.name}": ${email}`)
+        }
+      }
+
+      // Step 2: If no Perplexity email, try website scraping enrichment
+      if (!email && org.website) {
+        const enrichment = await enrichOrganization(org.website, null, org.name)
+        diagnostics.enriched++
+
+        if (enrichment.email) {
+          const emailDomain = enrichment.email.split('@')[1]?.toLowerCase() || ''
+          if (!thirdPartyDomains.some(d => emailDomain.includes(d))) {
+            email = enrichment.email
+            firstName = enrichment.firstName || 'Contact'
+            lastName = enrichment.lastName || `at ${org.name}`
+            contactTitle = enrichment.contactTitle
+            enrichmentSource = enrichment.enrichmentSource || 'website_scrape'
+            emailVerified = enrichment.emailVerified
+            phone = enrichment.phone
+          }
+        }
+      }
+
+      // Step 3: If still no email and no website, skip
+      if (!email) {
+        if (!org.website && !org.email) {
+          console.log(`[Perplexity Research] No website or email for "${org.name}" — skipping`)
+        } else {
+          console.log(`[Perplexity Research] No email found for "${org.name}" — skipping`)
+        }
         continue
       }
 
-      const enrichment = await enrichOrganization(org.website, null, org.name)
-      diagnostics.enriched++
+      const baseScore = firstName !== 'Contact' ? 45 : 35
 
-      if (enrichment.email) {
-        // Filter out third-party SaaS emails
-        const thirdPartyDomains = [
-          'mymusicstaff.com', 'groupanizer.com', 'placeholder.local',
-          'wixpress.com', 'squarespace.com', 'wordpress.com',
-          'mailchimp.com', 'constantcontact.com',
-        ]
-        const emailDomain = enrichment.email.split('@')[1]?.toLowerCase() || ''
-        if (thirdPartyDomains.some(d => emailDomain.includes(d))) {
-          console.log(`[Perplexity Research] Skipping third-party email ${enrichment.email} for "${org.name}"`)
-          continue
-        }
-
-        const baseScore = enrichment.firstName && enrichment.firstName !== 'Contact' ? 45 : 35
-
-        leads.push({
-          firstName: enrichment.firstName || 'Contact',
-          lastName: enrichment.lastName || `at ${org.name}`,
-          email: enrichment.email,
-          phone: enrichment.phone,
-          organization: org.name,
-          source: 'AI_RESEARCH',
-          latitude: campaign.latitude,
-          longitude: campaign.longitude,
-          score: baseScore,
-          distance: 0,
-          website: org.website,
-          emailVerified: enrichment.emailVerified,
-          needsEnrichment: false,
-          enrichmentSource: enrichment.enrichmentSource || 'perplexity+firecrawl',
-          contactTitle: enrichment.contactTitle,
-          editorialSummary: org.description?.substring(0, 200) || null,
-        })
-      } else {
-        console.log(`[Perplexity Research] No email found for "${org.name}" — skipping`)
-      }
+      leads.push({
+        firstName,
+        lastName,
+        email,
+        phone,
+        organization: org.name,
+        source: 'AI_RESEARCH',
+        latitude: campaign.latitude,
+        longitude: campaign.longitude,
+        score: baseScore,
+        distance: 0,
+        website: org.website,
+        emailVerified,
+        needsEnrichment: false,
+        enrichmentSource,
+        contactTitle,
+        editorialSummary: org.description?.substring(0, 200) || null,
+      })
     } catch (error) {
       console.error(`[Perplexity Research] Failed to enrich "${org.name}":`, error instanceof Error ? error.message : error)
     }

--- a/src/lib/enrichment/http-scraper.ts
+++ b/src/lib/enrichment/http-scraper.ts
@@ -1,0 +1,298 @@
+/**
+ * Plain HTTP Website Scraper — No Firecrawl Dependency
+ *
+ * Uses Node.js fetch() to grab HTML from org websites and extract
+ * contact emails, names, and titles. Works even when Firecrawl credits
+ * are exhausted.
+ *
+ * Strategy: scrape homepage + /contact + /about (max 3 pages).
+ * Extract emails with context-aware name/title detection.
+ */
+
+import { isValidContactName, stripTitlePrefix } from './name-validator'
+import type { ScrapedEmail, ScrapeResult } from './website-scraper'
+
+// Pages most likely to contain contact info
+const CONTACT_PATHS = ['/contact', '/about', '/about-us', '/staff', '/leadership']
+
+// Generic email prefixes
+const GENERIC_PREFIXES = [
+  'info', 'admin', 'office', 'contact', 'hello', 'help',
+  'support', 'noreply', 'no-reply', 'webmaster', 'mail',
+  'general', 'enquiries', 'inquiries', 'reception', 'membership', 'secretary',
+]
+
+// Leadership titles
+const LEADERSHIP_TITLES = [
+  'music director', 'artistic director', 'chorus master', 'choirmaster',
+  'conductor', 'director of music', 'president', 'executive director',
+  'managing director', 'chair', 'chairperson', 'board president',
+  'vocal director', 'associate director',
+]
+
+const EMAIL_REGEX = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g
+const NAME_PATTERN = /(?:(?:Dr|Rev|Prof|Mr|Mrs|Ms)\.?\s+)?([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)/g
+
+// Skip domains that aren't the org's own contacts
+const SKIP_DOMAINS = [
+  'mymusicstaff.com', 'groupanizer.com', 'wixpress.com',
+  'squarespace.com', 'wordpress.com', 'mailchimp.com',
+  'constantcontact.com', 'google.com', 'googleapis.com',
+  'w3.org', 'schema.org', 'cloudflare.com', 'jquery.com',
+  'sentry.io', 'placeholder.local', 'example.com',
+  'bootstrapcdn.com', 'github.com', 'gravatar.com',
+]
+
+/**
+ * Fetch a page's HTML using plain HTTP (no API credits)
+ */
+async function fetchPage(url: string): Promise<string | null> {
+  try {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 8000)
+
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; LeadBot/1.0)',
+        'Accept': 'text/html,application/xhtml+xml',
+      },
+      redirect: 'follow',
+    })
+
+    clearTimeout(timeout)
+
+    if (!response.ok) return null
+
+    const contentType = response.headers.get('content-type') || ''
+    if (!contentType.includes('text/html') && !contentType.includes('text/plain')) return null
+
+    const html = await response.text()
+    // Limit to 200KB
+    return html.substring(0, 200_000)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Strip HTML tags to get readable text, preserving some structure
+ */
+function htmlToText(html: string): string {
+  return html
+    // Remove script/style blocks entirely
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<noscript[\s\S]*?<\/noscript>/gi, ' ')
+    // Convert block elements to newlines
+    .replace(/<\/?(p|div|br|h[1-6]|li|tr|td|th|section|article|header|footer|nav)[^>]*>/gi, '\n')
+    // Remove remaining tags
+    .replace(/<[^>]+>/g, ' ')
+    // Decode common HTML entities
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    // Collapse whitespace
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n\s*\n/g, '\n')
+    .trim()
+}
+
+/**
+ * Also extract emails from raw HTML (mailto: links, etc.)
+ */
+function extractEmailsFromHtml(html: string): string[] {
+  const mailtoRegex = /mailto:([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/g
+  const emails: string[] = []
+  let match
+  while ((match = mailtoRegex.exec(html)) !== null) {
+    emails.push(match[1].toLowerCase())
+  }
+  return emails
+}
+
+function classifyEmail(email: string): 'personal' | 'generic' {
+  const localPart = email.split('@')[0].toLowerCase()
+  if (GENERIC_PREFIXES.some(prefix => localPart === prefix)) return 'generic'
+  if (/^[a-z]+\.[a-z]+$/.test(localPart)) return 'personal'
+  if (/^[a-z]{2,}$/.test(localPart) && !GENERIC_PREFIXES.includes(localPart)) return 'personal'
+  return 'generic'
+}
+
+function extractNameNearEmail(text: string, emailIndex: number): { name: string | null; title: string | null } {
+  const start = Math.max(0, emailIndex - 300)
+  const end = Math.min(text.length, emailIndex + 100)
+  const context = text.substring(start, end)
+
+  // Find title
+  let title: string | null = null
+  for (const t of LEADERSHIP_TITLES) {
+    if (context.toLowerCase().includes(t)) {
+      title = t.split(' ').map(w => w[0].toUpperCase() + w.slice(1)).join(' ')
+      break
+    }
+  }
+
+  // Find name before email
+  const beforeEmail = text.substring(start, emailIndex)
+  const names: string[] = []
+  let match
+  const regex = new RegExp(NAME_PATTERN.source, 'g')
+  while ((match = regex.exec(beforeEmail)) !== null) {
+    names.push(match[1]?.trim() || match[0].trim())
+  }
+
+  let name: string | null = names.length > 0 ? names[names.length - 1] : null
+  if (name) {
+    const stripped = stripTitlePrefix(name)
+    if (!isValidContactName(stripped.name)) {
+      return { name: null, title: stripped.title || title }
+    }
+    return { name: stripped.name, title: stripped.title || title }
+  }
+
+  return { name: null, title }
+}
+
+/**
+ * Extract contacts from text content of a page
+ */
+function extractContacts(text: string, orgDomain: string): ScrapedEmail[] {
+  const contacts: ScrapedEmail[] = []
+  const seenEmails = new Set<string>()
+
+  let match
+  const regex = new RegExp(EMAIL_REGEX.source, 'g')
+  while ((match = regex.exec(text)) !== null) {
+    const email = match[0].toLowerCase()
+    if (seenEmails.has(email)) continue
+
+    // Skip non-email extensions
+    if (/\.(png|jpg|gif|css|js|svg|webp)$/i.test(email)) continue
+
+    // Skip third-party domains
+    const emailDomain = email.split('@')[1] || ''
+    if (SKIP_DOMAINS.some(d => emailDomain.includes(d))) continue
+
+    // Keep emails from org's domain or common providers
+    const isOrgDomain = emailDomain === orgDomain || emailDomain === `www.${orgDomain}`
+    const isCommonProvider = ['gmail.com', 'yahoo.com', 'outlook.com', 'hotmail.com', 'aol.com', 'icloud.com', 'comcast.net', 'verizon.net'].includes(emailDomain)
+    if (!isOrgDomain && !isCommonProvider) continue
+
+    seenEmails.add(email)
+
+    const { name, title } = extractNameNearEmail(text, match.index)
+    contacts.push({
+      email,
+      name,
+      title,
+      type: classifyEmail(email),
+    })
+  }
+
+  return contacts
+}
+
+/**
+ * Scrape a website using plain HTTP fetch (no Firecrawl API needed)
+ *
+ * Tries homepage + up to 2 subpages (/contact, /about, etc.)
+ * Max 3 HTTP requests per org.
+ */
+export async function httpScrapeWebsite(websiteUrl: string): Promise<ScrapeResult> {
+  let baseUrl: string
+  try {
+    const url = new URL(websiteUrl.startsWith('http') ? websiteUrl : `https://${websiteUrl}`)
+    baseUrl = `${url.protocol}//${url.host}`
+  } catch {
+    return { emails: [], source: 'website_scrape' }
+  }
+
+  const orgDomain = new URL(baseUrl).hostname.replace(/^www\./, '')
+  const allEmails = new Map<string, ScrapedEmail>()
+  let pagesScraped = 0
+
+  // Scrape homepage first
+  const homeHtml = await fetchPage(baseUrl)
+  if (homeHtml) {
+    pagesScraped++
+    const text = htmlToText(homeHtml)
+    const mailtoEmails = extractEmailsFromHtml(homeHtml)
+
+    // Extract from text
+    for (const contact of extractContacts(text, orgDomain)) {
+      if (!allEmails.has(contact.email)) allEmails.set(contact.email, contact)
+    }
+
+    // Also check mailto links (sometimes obfuscated in HTML)
+    for (const email of mailtoEmails) {
+      if (!allEmails.has(email)) {
+        allEmails.set(email, {
+          email,
+          name: null,
+          title: null,
+          type: classifyEmail(email),
+        })
+      }
+    }
+  }
+
+  // If we found a personal email with a name, we're done
+  const hasGoodEmail = Array.from(allEmails.values()).some(e => e.type === 'personal' && e.name)
+  if (!hasGoodEmail) {
+    // Try contact/about pages (max 2 more)
+    for (const path of CONTACT_PATHS) {
+      if (pagesScraped >= 3) break
+
+      // Small delay between requests to be polite
+      await new Promise(resolve => setTimeout(resolve, 200))
+
+      const html = await fetchPage(`${baseUrl}${path}`)
+      if (!html) continue
+
+      pagesScraped++
+      const text = htmlToText(html)
+      const mailtoEmails = extractEmailsFromHtml(html)
+
+      for (const contact of extractContacts(text, orgDomain)) {
+        const existing = allEmails.get(contact.email)
+        if (!existing) {
+          allEmails.set(contact.email, contact)
+        } else {
+          // Upgrade with name/title if found
+          if (contact.name && !existing.name) existing.name = contact.name
+          if (contact.title && !existing.title) existing.title = contact.title
+          if (contact.name && existing.type === 'generic') existing.type = 'personal'
+        }
+      }
+
+      for (const email of mailtoEmails) {
+        if (!allEmails.has(email)) {
+          allEmails.set(email, {
+            email,
+            name: null,
+            title: null,
+            type: classifyEmail(email),
+          })
+        }
+      }
+
+      // Stop if we found a personal email
+      if (Array.from(allEmails.values()).some(e => e.type === 'personal' && e.name)) break
+    }
+  }
+
+  // Sort by quality
+  const sorted = Array.from(allEmails.values()).sort((a, b) => {
+    const scoreA = (a.type === 'personal' ? 10 : 0) + (a.name ? 5 : 0) + (a.title ? 8 : 0)
+    const scoreB = (b.type === 'personal' ? 10 : 0) + (b.name ? 5 : 0) + (b.title ? 8 : 0)
+    return scoreB - scoreA
+  })
+
+  console.log(`[HTTP Scraper] ${websiteUrl}: scraped ${pagesScraped} pages, found ${sorted.length} emails`)
+
+  return { emails: sorted, source: 'website_scrape' }
+}

--- a/src/lib/enrichment/index.ts
+++ b/src/lib/enrichment/index.ts
@@ -8,7 +8,12 @@
 
 import { scrapeWebsite, type ScrapedEmail } from './website-scraper'
 import { firecrawlScrape, isFirecrawlAvailable } from './firecrawl-scraper'
+import { httpScrapeWebsite } from './http-scraper'
 import { isValidContactName, stripTitlePrefix } from './name-validator'
+
+// Track Firecrawl credit exhaustion across the session
+let firecrawlDisabled = false
+let firecrawlFailCount = 0
 
 export interface EnrichmentResult {
   email: string | null
@@ -56,33 +61,44 @@ export async function enrichOrganization(
   }
 
   try {
-    // Try Firecrawl first (better at JS-rendered sites + diverse layouts)
-    // Falls back to custom scraper if Firecrawl unavailable or fails
+    // Strategy: Use plain HTTP scraper first (free, no API credits).
+    // Only try Firecrawl if HTTP scraper finds nothing AND Firecrawl has credits.
     let scrapeResult: { emails: ScrapedEmail[] }
 
-    if (isFirecrawlAvailable()) {
-      try {
-        scrapeResult = await firecrawlScrape(websiteUrl)
-        if (scrapeResult.emails.length > 0) {
-          console.log(`[Enrichment] Firecrawl found ${scrapeResult.emails.length} emails for "${orgName}"`)
-        }
-      } catch (fcError) {
-        console.warn(`[Enrichment] Firecrawl failed for "${orgName}", falling back to custom scraper:`, fcError instanceof Error ? fcError.message : fcError)
-        scrapeResult = await scrapeWebsite(websiteUrl)
+    // Step 1: Plain HTTP scraper (always available, no API dependency)
+    try {
+      scrapeResult = await httpScrapeWebsite(websiteUrl)
+      if (scrapeResult.emails.length > 0) {
+        console.log(`[Enrichment] HTTP scraper found ${scrapeResult.emails.length} emails for "${orgName}"`)
       }
-    } else {
-      scrapeResult = await scrapeWebsite(websiteUrl)
+    } catch (httpError) {
+      console.warn(`[Enrichment] HTTP scraper failed for "${orgName}":`, httpError instanceof Error ? httpError.message : httpError)
+      scrapeResult = { emails: [] }
     }
 
-    // If Firecrawl found nothing, try custom scraper as backup
-    if (scrapeResult.emails.length === 0 && isFirecrawlAvailable()) {
+    // Step 2: If no emails found and Firecrawl available (with credits), try it as upgrade
+    if (scrapeResult.emails.length === 0 && isFirecrawlAvailable() && !firecrawlDisabled) {
       try {
-        const fallbackResult = await scrapeWebsite(websiteUrl)
-        if (fallbackResult.emails.length > 0) {
-          console.log(`[Enrichment] Custom scraper found ${fallbackResult.emails.length} emails (Firecrawl missed them) for "${orgName}"`)
-          scrapeResult = fallbackResult
+        const fcResult = await firecrawlScrape(websiteUrl)
+        if (fcResult.emails.length > 0) {
+          console.log(`[Enrichment] Firecrawl found ${fcResult.emails.length} emails for "${orgName}" (HTTP scraper missed)`)
+          scrapeResult = fcResult
+          firecrawlFailCount = 0 // Reset on success
         }
-      } catch { /* ignore fallback failure */ }
+      } catch (fcError) {
+        firecrawlFailCount++
+        const errMsg = fcError instanceof Error ? fcError.message : String(fcError)
+        console.warn(`[Enrichment] Firecrawl failed for "${orgName}": ${errMsg}`)
+
+        // Detect credit exhaustion — disable Firecrawl for rest of session
+        if (errMsg.includes('402') || errMsg.includes('Insufficient credits') || errMsg.includes('429')) {
+          firecrawlDisabled = true
+          console.warn('[Enrichment] Firecrawl credits exhausted — disabling for this session')
+        } else if (firecrawlFailCount >= 3) {
+          firecrawlDisabled = true
+          console.warn('[Enrichment] Firecrawl failed 3 times — disabling for this session')
+        }
+      }
     }
 
     if (scrapeResult.emails.length === 0) {

--- a/src/lib/enrichment/website-scraper.ts
+++ b/src/lib/enrichment/website-scraper.ts
@@ -208,47 +208,44 @@ function extractTitleEmailPairs(text: string): ScrapedEmail[] {
 }
 
 /**
- * Scrape a URL using Firecrawl API
- * Returns markdown content, or null on failure
+ * Scrape a URL using plain HTTP fetch.
+ * Strips HTML to get readable text for email/name extraction.
  */
-async function firecrawlScrape(url: string): Promise<string | null> {
-  const apiKey = process.env.FIRECRAWL_API_KEY
-  if (!apiKey) return null
-
+async function fetchAndConvertToText(url: string): Promise<string | null> {
   try {
-    const response = await fetch('https://api.firecrawl.dev/v1/scrape', {
-      method: 'POST',
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 8000)
+
+    const response = await fetch(url, {
+      signal: controller.signal,
       headers: {
-        'Authorization': `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
+        'User-Agent': 'Mozilla/5.0 (compatible; LeadBot/1.0)',
+        'Accept': 'text/html,application/xhtml+xml',
       },
-      body: JSON.stringify({
-        url,
-        formats: ['markdown'],
-        onlyMainContent: true,
-        timeout: 10000,
-      }),
+      redirect: 'follow',
     })
 
-    if (!response.ok) {
-      console.error(`[Scraper] Firecrawl scrape failed for ${url}: ${response.status}`)
-      return null
-    }
+    clearTimeout(timeout)
 
-    const data = await response.json()
+    if (!response.ok) return null
 
-    if (!data.success) {
-      console.error(`[Scraper] Firecrawl scrape unsuccessful for ${url}:`, data.error || 'unknown')
-      return null
-    }
-
-    const markdown = data.data?.markdown
-    if (!markdown) return null
-
-    // Limit to first 100KB to avoid processing huge pages
-    return markdown.substring(0, 100_000)
-  } catch (error) {
-    console.error(`[Scraper] Firecrawl scrape error for ${url}:`, error)
+    const html = await response.text()
+    // Strip HTML to text
+    return html
+      .substring(0, 200_000)
+      .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/&nbsp;/g, ' ')
+      .replace(/[ \t]+/g, ' ')
+      .replace(/\n\s*\n/g, '\n')
+      .trim()
+  } catch {
     return null
   }
 }
@@ -285,7 +282,7 @@ export async function scrapeWebsite(websiteUrl: string): Promise<ScrapeResult> {
 
   const allEmails = new Map<string, ScrapedEmail>()
   let pagesScraped = 0
-  const maxPages = 4 // Homepage + 3 contact pages (keeps enrichment fast)
+  const maxPages = 3 // Homepage + 2 contact pages (keeps enrichment fast)
 
   // Scrape homepage + contact pages
   const pagesToScrape = [baseUrl, ...CONTACT_PATHS.map(path => `${baseUrl}${path}`)]
@@ -293,7 +290,7 @@ export async function scrapeWebsite(websiteUrl: string): Promise<ScrapeResult> {
   for (const pageUrl of pagesToScrape) {
     if (pagesScraped >= maxPages) break
 
-    const text = await firecrawlScrape(pageUrl)
+    const text = await fetchAndConvertToText(pageUrl)
     if (!text) continue
 
     pagesScraped++


### PR DESCRIPTION
## Summary
- **New plain HTTP scraper** — uses `fetch()` directly, no API credits needed. Scrapes homepage + /contact + /about (max 3 pages per org)
- **Perplexity now returns contact emails directly** — orgs with AI-provided emails skip scraping entirely (free enrichment)
- **Firecrawl demoted to optional upgrade** — only tried when HTTP scraper finds nothing. Detects 402/429 credit exhaustion and disables itself for the session

## Problem
Firecrawl credits exhausted → all 35+ orgs found by Perplexity got 0 leads. The old scraper was burning 700+ API calls (16 URL variants × 35 orgs) with no rate limiting.

## Test plan
- [ ] Deploy to Railway
- [ ] Delete existing campaign, create new one
- [ ] Verify leads are created (should see 10+ from Perplexity + HTTP scraping)
- [ ] Confirm no Firecrawl 402 errors in logs

https://claude.ai/code/session_019zv7k9ssVntZj57CUexzNa