### PR TITLE
Create leads without emails + loosen domain filters

### DIFF
--- a/src/lib/discovery/perplexity-research.ts
+++ b/src/lib/discovery/perplexity-research.ts
@@ -372,22 +372,23 @@ export async function discoverWithPerplexity(campaign: Campaign): Promise<AIRese
         }
       }
 
-      // Step 3: If still no email and no website, skip
-      if (!email) {
-        if (!org.website && !org.email) {
-          console.log(`[Perplexity Research] No website or email for "${org.name}" — skipping`)
-        } else {
-          console.log(`[Perplexity Research] No email found for "${org.name}" — skipping`)
-        }
-        continue
+      // Create lead even without email — org name + website is still a valuable lead
+      const hasEmail = !!email
+      const baseScore = hasEmail
+        ? (firstName !== 'Contact' ? 45 : 35)
+        : (org.website ? 20 : 10) // Lower score for leads needing enrichment
+
+      if (!hasEmail) {
+        console.log(`[Perplexity Research] No email for "${org.name}" — creating lead with needsEnrichment=true`)
       }
 
-      const baseScore = firstName !== 'Contact' ? 45 : 35
+      // Generate a placeholder email for leads without one (required by DB unique constraint)
+      const leadEmail = email || `needs-enrichment+${org.name.toLowerCase().replace(/[^a-z0-9]/g, '-')}@placeholder.local`
 
       leads.push({
         firstName,
         lastName,
-        email,
+        email: leadEmail,
         phone,
         organization: org.name,
         source: 'AI_RESEARCH',
@@ -396,9 +397,9 @@ export async function discoverWithPerplexity(campaign: Campaign): Promise<AIRese
         score: baseScore,
         distance: 0,
         website: org.website,
-        emailVerified,
-        needsEnrichment: false,
-        enrichmentSource,
+        emailVerified: hasEmail ? emailVerified : false,
+        needsEnrichment: !hasEmail,
+        enrichmentSource: hasEmail ? enrichmentSource : null,
         contactTitle,
         editorialSummary: org.description?.substring(0, 200) || null,
       })

--- a/src/lib/enrichment/http-scraper.ts
+++ b/src/lib/enrichment/http-scraper.ts
@@ -177,10 +177,8 @@ function extractContacts(text: string, orgDomain: string): ScrapedEmail[] {
     const emailDomain = email.split('@')[1] || ''
     if (SKIP_DOMAINS.some(d => emailDomain.includes(d))) continue
 
-    // Keep emails from org's domain or common providers
-    const isOrgDomain = emailDomain === orgDomain || emailDomain === `www.${orgDomain}`
-    const isCommonProvider = ['gmail.com', 'yahoo.com', 'outlook.com', 'hotmail.com', 'aol.com', 'icloud.com', 'comcast.net', 'verizon.net'].includes(emailDomain)
-    if (!isOrgDomain && !isCommonProvider) continue
+    // Accept any non-junk email domain (org domain, personal providers, etc.)
+    // The SKIP_DOMAINS list already filters out platform/SaaS emails above
 
     seenEmails.add(email)
 

--- a/src/lib/enrichment/website-scraper.ts
+++ b/src/lib/enrichment/website-scraper.ts
@@ -342,12 +342,17 @@ export async function scrapeWebsite(websiteUrl: string): Promise<ScrapeResult> {
     }
   }
 
-  // Filter: keep emails from org's own domain or common providers
-  const websiteDomain = new URL(baseUrl).hostname.replace(/^www\./, '')
+  // Filter: reject known platform/SaaS emails, keep everything else
+  const platformDomains = [
+    'mymusicstaff.com', 'groupanizer.com', 'wixpress.com',
+    'squarespace.com', 'wordpress.com', 'mailchimp.com',
+    'constantcontact.com', 'google.com', 'googleapis.com',
+    'w3.org', 'schema.org', 'cloudflare.com', 'sentry.io',
+    'placeholder.local', 'example.com',
+  ]
   const filteredEmails = Array.from(allEmails.values()).filter(e => {
     const emailDomain = e.email.split('@')[1]
-    return emailDomain === websiteDomain ||
-      ['gmail.com', 'yahoo.com', 'outlook.com', 'hotmail.com'].includes(emailDomain)
+    return !platformDomains.some(d => emailDomain.includes(d))
   })
 
   // Sort by priority:


### PR DESCRIPTION
## Summary
- Create leads even without emails — mark as `needsEnrichment=true` with lower score, so Deke sees all 35+ discovered orgs instead of only the 3 with scraped emails
- Loosen email domain filtering — accept any non-platform email (was only accepting org-domain or gmail/yahoo, missing tons of valid contacts)

## Problem
Previous deploy found 35 orgs but only created 3 leads because orgs without emails were completely dropped.

## Test plan
- [ ] Deploy, delete campaign, create new one
- [ ] Should see 20+ leads (mix of enriched + needs-enrichment)

https://claude.ai/code/session_019zv7k9ssVntZj57CUexzNa