### PR TITLE
Personalize outreach email subjects with organization names

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -342,27 +342,33 @@ async function main() {
   // -----------------------------------------------------------
   await prisma.messageTemplate.upsert({
     where: { id: 'seed-template-university' },
-    update: {},
+    update: {
+      subject: 'Coming to {{baseLocation}} — a thought for {{organization}}',
+      body: 'Hi {{firstName}},\n\nI\'m Deke Sharon — I\'ll be in the {{baseLocation}} area{{availabilityDates}} and wanted to reach out to {{organization}} directly.\n\nI\'ve worked with collegiate a cappella groups across the country on everything from arranging and blend to performance and show design. If there\'s a good fit with where your group is right now, I\'d love a quick conversation.\n\nNo pitch, no pressure — just want to see if the timing and format make sense.\n\nWarm regards,\nDeke Sharon\n{{servicesLink}}',
+    },
     create: {
       id: 'seed-template-university',
       name: 'Workshop Inquiry - University',
       serviceType: 'WORKSHOP',
       channel: 'EMAIL',
-      subject: 'A Cappella Workshop Opportunity Near Your Area',
-      body: 'Hi {{firstName}},\n\nI noticed {{organization}} might be interested in elevating your a cappella program. Deke Sharon (Music Director of Pitch Perfect, The Sing-Off) will be in {{location}} on {{dates}} and has availability for a workshop.\n\nTopics can include:\n- Arranging techniques\n- Vocal percussion\n- Blend and tuning\n- Performance skills\n\nInvestment: $3,500-6,000 depending on group size and duration.\n\nWould you be interested in learning more?\n\nBest regards,\nHarmony',
+      subject: 'Coming to {{baseLocation}} — a thought for {{organization}}',
+      body: 'Hi {{firstName}},\n\nI\'m Deke Sharon — I\'ll be in the {{baseLocation}} area{{availabilityDates}} and wanted to reach out to {{organization}} directly.\n\nI\'ve worked with collegiate a cappella groups across the country on everything from arranging and blend to performance and show design. If there\'s a good fit with where your group is right now, I\'d love a quick conversation.\n\nNo pitch, no pressure — just want to see if the timing and format make sense.\n\nWarm regards,\nDeke Sharon\n{{servicesLink}}',
     },
   })
 
   await prisma.messageTemplate.upsert({
     where: { id: 'seed-template-highschool' },
-    update: {},
+    update: {
+      subject: 'A thought for {{organization}} — Deke Sharon in {{baseLocation}}',
+      body: 'Hi {{firstName}},\n\nI\'m Deke Sharon — I\'ll be in {{baseLocation}}{{availabilityDates}} and I wanted to reach out to {{organization}} directly.\n\nI work with high school vocal groups on the things that make the biggest difference: how to listen, how to blend, how to arrange for your specific voices, and how to perform with confidence. Sessions are tailored to where your singers actually are.\n\nIf the timing feels right, I\'d love to have a brief conversation about what might work.\n\nWarm regards,\nDeke Sharon\n{{servicesLink}}',
+    },
     create: {
       id: 'seed-template-highschool',
       name: 'Workshop Inquiry - High School',
       serviceType: 'WORKSHOP',
       channel: 'EMAIL',
-      subject: 'Special Workshop Opportunity for {{organization}}',
-      body: "Hi {{firstName}},\n\nDeke Sharon, the \"father of contemporary a cappella,\" will be in {{location}} on {{dates}}.\n\nWe're offering a limited number of high school workshops at a special rate: $2,500 for a half-day session.\n\nYour singers will learn directly from the Music Director of Pitch Perfect and The Sing-Off.\n\nInterested in reserving a spot?\n\nBest,\nHarmony",
+      subject: 'A thought for {{organization}} — Deke Sharon in {{baseLocation}}',
+      body: 'Hi {{firstName}},\n\nI\'m Deke Sharon — I\'ll be in {{baseLocation}}{{availabilityDates}} and I wanted to reach out to {{organization}} directly.\n\nI work with high school vocal groups on the things that make the biggest difference: how to listen, how to blend, how to arrange for your specific voices, and how to perform with confidence. Sessions are tailored to where your singers actually are.\n\nIf the timing feels right, I\'d love to have a brief conversation about what might work.\n\nWarm regards,\nDeke Sharon\n{{servicesLink}}',
     },
   })
 

--- a/src/lib/discovery/draft-generator.ts
+++ b/src/lib/discovery/draft-generator.ts
@@ -15,6 +15,55 @@ export interface DraftGenerationResult {
 }
 
 /**
+ * Determine a sensible greeting name for the lead.
+ *
+ * Handles three cases:
+ *  1. A real person name is available → use firstName
+ *  2. firstName is the placeholder pattern "Contact at Org" → fall back to org or "there"
+ *  3. firstName looks like an institution/org name (capitalized single word like "MIT",
+ *     "Harvard") → fall back to org team or "there"
+ */
+function resolveGreeting(firstName: string, lastName: string | null, organization: string | null): string {
+  // Placeholder pattern used by discovery when no contact is found
+  if (firstName === 'Contact' && lastName?.startsWith('at ')) {
+    return organization ? `${organization} team` : 'there'
+  }
+
+  // Institution name used as firstName (e.g. "MIT", "Harvard", "Tufts")
+  // Heuristic: single capitalized word that matches common institution patterns
+  const looksLikeInstitution = /^[A-Z][A-Za-z]+$/.test(firstName) && firstName.length >= 3
+  if (looksLikeInstitution && organization && organization.startsWith(firstName)) {
+    return organization ? `${organization} team` : 'there'
+  }
+
+  return firstName
+}
+
+/**
+ * Build the fallback email body template when no MessageTemplate record exists.
+ *
+ * The body is personalized: if editorialSummary is available for this lead, a
+ * paragraph acknowledging what the group does is included, making the email feel
+ * researched rather than mass-sent.
+ */
+function buildFallbackBody(hasEditorialSummary: boolean): string {
+  const editorialParagraph = hasEditorialSummary
+    ? '\nI came across {{organization}} — {{editorialSummary}} That kind of work is exactly what I love getting to be part of.\n'
+    : ''
+
+  return `Hi {{firstName}},
+
+I'm Deke Sharon — I'll be in the {{baseLocation}} area{{availabilityDates}} and wanted to reach out directly.
+${editorialParagraph}
+I work with vocal groups of all kinds on workshops, coaching, and masterclasses. If the timing feels right and there's a good fit, I'd love a quick conversation — no pressure either way.
+
+You can see what I offer at {{servicesLink}}
+
+Warm regards,
+Deke Sharon`
+}
+
+/**
  * Generate email drafts for all leads in a campaign that have usable emails.
  *
  * @param campaignId - The campaign to generate drafts for
@@ -64,28 +113,11 @@ export async function generateDraftsForCampaign(campaignId: string): Promise<Dra
   const workshopLink = `${baseUrl}/workshops`
   const servicesLink = `${baseUrl}/services`
 
-  // Find template
-  let templateSubject = buildDefaultSubject(campaign.baseLocation, campaign.booking?.serviceType)
-  let templateBody = `Hi {{firstName}},
-
-I'm Deke Sharon, and I'll be in the {{baseLocation}} area{{availabilityDates}} — I'd love to explore working with {{organization}}.
-
-I offer workshops, coaching, and masterclasses tailored to vocal groups of all levels. You can see the full list of what I offer here: {{workshopLink}}
-
-Would you be open to a quick conversation about what might be a good fit?
-
-Best,
-Deke Sharon
-{{servicesLink}}`
-
+  // Find the most recent EMAIL template to use as default
   const defaultTemplate = await prisma.messageTemplate.findFirst({
     where: { channel: 'EMAIL' },
     orderBy: { createdAt: 'desc' },
   })
-  if (defaultTemplate) {
-    templateSubject = defaultTemplate.subject || templateSubject
-    templateBody = defaultTemplate.body
-  }
 
   // Get campaign leads that have real emails
   const campaignLeads = await prisma.campaignLead.findMany({
@@ -113,15 +145,19 @@ Deke Sharon
       continue
     }
 
-    // Use org-based greeting when no real person name is available
-    let greeting = cl.lead.firstName
-    if (cl.lead.firstName === 'Contact' && cl.lead.lastName?.startsWith('at ')) {
-      greeting = cl.lead.organization ? `${cl.lead.organization} team` : 'there'
-    }
+    const greeting = resolveGreeting(cl.lead.firstName, cl.lead.lastName, cl.lead.organization)
+    const hasEditorialSummary = Boolean(cl.lead.editorialSummary?.trim())
+
+    // Build subject: per-lead personalization using org name
+    let templateSubject = defaultTemplate?.subject
+      ?? buildDefaultSubject(campaign.baseLocation, campaign.booking?.serviceType, cl.lead.organization)
+
+    // Build body: use DB template if available, otherwise the personalized fallback
+    let templateBody = defaultTemplate?.body ?? buildFallbackBody(hasEditorialSummary)
 
     const vars: Record<string, string> = {
       firstName: greeting,
-      lastName: cl.lead.lastName,
+      lastName: cl.lead.lastName ?? '',
       organization: cl.lead.organization || '',
       contactTitle: cl.lead.contactTitle || '',
       editorialSummary: cl.lead.editorialSummary || '',

--- a/src/lib/outreach/default-subject.ts
+++ b/src/lib/outreach/default-subject.ts
@@ -1,19 +1,164 @@
 /**
- * Builds a contextual default email subject based on campaign location and booking service type.
+ * Builds a contextual, personalized email subject based on campaign location,
+ * booking service type, and the target organization name.
+ *
+ * Goals: feel personal, reference location and org specifically, never feel like
+ * a mass-blast or a "sales opportunity" pitch.
  */
 
-const SERVICE_LABELS: Record<string, string> = {
-  ARRANGEMENT: 'Arrangement',
-  GROUP_COACHING: 'A Cappella Coaching',
-  INDIVIDUAL_COACHING: 'Vocal Coaching',
-  WORKSHOP: 'A Cappella Workshop',
-  SPEAKING: 'Speaking',
-  MASTERCLASS: 'Masterclass',
-  CONSULTATION: 'Consultation',
+const SERVICE_TEMPLATES: Record<string, string[]> = {
+  WORKSHOP: [
+    'Coming to {city} — a thought for {org}',
+    'Working in {city} this {season} — curious about {org}',
+    'A quick note to {org} — I\'ll be in {city}',
+    'In {city} soon — would love to work with {org}',
+  ],
+  GROUP_COACHING: [
+    'Coaching in {city} — thinking about {org}',
+    'Coming to {city} — wondering if this is a fit for {org}',
+    'A thought for {org} — I\'ll be in {city}',
+    'In {city} soon — a note for {org}',
+  ],
+  INDIVIDUAL_COACHING: [
+    'Coming to {city} — a note for {org}',
+    'In {city} soon — wondering about {org}',
+    'A thought for {org} while I\'m in {city}',
+    'Vocal coaching in {city} — thinking of {org}',
+  ],
+  MASTERCLASS: [
+    'A masterclass in {city} — wondering about {org}',
+    'Coming to {city} — a thought for {org}',
+    'In {city} for a masterclass — curious about {org}',
+    'A note for {org} — I\'ll be in {city}',
+  ],
+  SPEAKING: [
+    'Speaking in {city} — a quick note for {org}',
+    'Coming to {city} — thinking about {org}',
+    'In {city} soon — wondering if there\'s a fit for {org}',
+    'A note for {org} while I\'m in {city}',
+  ],
+  ARRANGEMENT: [
+    'Coming to {city} — a thought for {org}',
+    'Arranging work in {city} — curious about {org}',
+    'A note for {org} — I\'ll be in {city}',
+    'In {city} soon — thinking of {org}',
+  ],
+  CONSULTATION: [
+    'Coming to {city} — a thought for {org}',
+    'In {city} soon — wondering about {org}',
+    'A note for {org} while I\'m in {city}',
+    'Thinking about {org} — I\'ll be in {city}',
+  ],
 }
 
-export function buildDefaultSubject(baseLocation: string, serviceType?: string | null): string {
-  const label = (serviceType && SERVICE_LABELS[serviceType]) || 'A Cappella'
+// Fallback templates when no org name is available
+const NO_ORG_TEMPLATES: Record<string, string[]> = {
+  WORKSHOP: [
+    'Coming to {city} — could this be a good fit?',
+    'Working in {city} this {season} — wondering if there\'s a match',
+    'In {city} soon — a quick thought',
+  ],
+  GROUP_COACHING: [
+    'Coaching visit to {city} — would love to connect',
+    'Coming to {city} — wondering if there\'s a fit',
+    'In {city} soon — a quick note',
+  ],
+  _default: [
+    'Coming to {city} — a quick thought',
+    'In {city} soon — wondering if there\'s a fit',
+    'A note while I\'m passing through {city}',
+  ],
+}
+
+function getSeason(date: Date = new Date()): string {
+  const month = date.getMonth() + 1
+  if (month >= 3 && month <= 5) return 'spring'
+  if (month >= 6 && month <= 8) return 'summer'
+  if (month >= 9 && month <= 11) return 'fall'
+  return 'winter'
+}
+
+/**
+ * Shorten an organization name for use in a subject line.
+ * E.g. "MIT Logarhythms" → "the Logarhythms"
+ *      "Harvard University Glee Club" → "Harvard Glee Club"
+ *      "Tufts Beelzebubs" → "the Beelzebubs"
+ *      "Northwestern Purple Haze" → "the Purple Haze"
+ */
+function shortenOrgForSubject(org: string): string {
+  // Strip common suffixes that add length without meaning in a subject
+  const suffixesToStrip = [
+    /\bUniversity\b/g,
+    /\bCollege\b/g,
+    /\bSchool of Music\b/g,
+    /\bConservatory\b/g,
+    /\bDepartment\b/g,
+    /\bA Cappella\b/g,
+  ]
+  let shortened = org
+  for (const suffix of suffixesToStrip) {
+    shortened = shortened.replace(suffix, '').trim()
+  }
+  // Collapse multiple spaces
+  shortened = shortened.replace(/\s+/g, ' ').trim()
+
+  // If the org has 2+ words and the first word looks like a university/location name,
+  // prefix with "the" to sound natural: "the Logarhythms", "the Beelzebubs"
+  const words = shortened.split(' ')
+  const INSTITUTION_PREFIXES = ['MIT', 'Harvard', 'Yale', 'Tufts', 'Northwestern', 'Columbia', 'UCLA', 'USC', 'UChicago', 'Stanford', 'Princeton', 'Cornell', 'Dartmouth', 'Brown', 'Penn']
+  if (words.length >= 2 && INSTITUTION_PREFIXES.includes(words[0])) {
+    // Use everything after the institution prefix, with "the"
+    const remainder = words.slice(1).join(' ')
+    if (remainder.length > 0) return `the ${remainder}`
+  }
+
+  // For other orgs, prefix with "the" if it's a group name (not a place/person name)
+  // Heuristic: if it doesn't end in common org-type words, add "the"
+  const ORG_TYPE_WORDS = ['Choir', 'Ensemble', 'Group', 'Club', 'Association', 'Institute', 'Center', 'Academy']
+  const lastWord = words[words.length - 1]
+  if (!ORG_TYPE_WORDS.includes(lastWord) && shortened.length <= 30) {
+    return `the ${shortened}`
+  }
+
+  return shortened
+}
+
+/**
+ * Pick a template deterministically based on the org name so the same org
+ * always gets the same subject variant, but different orgs in the same campaign
+ * get different phrasing (avoiding a wall of identical subjects in the review UI).
+ */
+function pickTemplate(templates: string[], seed: string): string {
+  let hash = 0
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash * 31 + seed.charCodeAt(i)) >>> 0
+  }
+  return templates[hash % templates.length]
+}
+
+export function buildDefaultSubject(
+  baseLocation: string,
+  serviceType?: string | null,
+  organization?: string | null,
+): string {
   const city = baseLocation.split(',')[0].trim()
-  return `${label} Opportunity in ${city} - Deke Sharon`
+  const season = getSeason()
+
+  if (organization) {
+    const orgShort = shortenOrgForSubject(organization)
+    const templates = (serviceType && SERVICE_TEMPLATES[serviceType]) || SERVICE_TEMPLATES.WORKSHOP
+    const template = pickTemplate(templates, organization)
+    return template
+      .replace('{city}', city)
+      .replace('{org}', orgShort)
+      .replace('{season}', season)
+  }
+
+  // No org name available
+  const key = (serviceType && NO_ORG_TEMPLATES[serviceType]) ? serviceType : '_default'
+  const templates = NO_ORG_TEMPLATES[key]
+  const template = pickTemplate(templates, city)
+  return template
+    .replace('{city}', city)
+    .replace('{season}', season)
 }


### PR DESCRIPTION
## Summary
Refactored email subject and body generation to create personalized, contextual outreach messages that reference the target organization and campaign location, replacing generic mass-blast style subjects.

## Key Changes

### Subject Line Personalization (`src/lib/outreach/default-subject.ts`)
- **Replaced generic labels** with service-specific subject templates that feel personal and conversational
- **Added organization name support** to `buildDefaultSubject()` function, enabling per-lead customization
- **Implemented `shortenOrgForSubject()`** to intelligently abbreviate organization names for subject lines (e.g., "MIT Logarhythms" → "the Logarhythms")
- **Added deterministic template selection** via `pickTemplate()` to ensure the same organization always receives the same subject variant, while different orgs get varied phrasing (improving review UI readability)
- **Added seasonal context** with `getSeason()` function for time-aware subject lines
- **Created fallback templates** for cases where organization name is unavailable

### Email Body Generation (`src/lib/discovery/draft-generator.ts`)
- **Implemented `resolveGreeting()`** to intelligently handle three greeting scenarios:
  - Real person names
  - Placeholder patterns ("Contact at Org")
  - Institution names used as firstName
- **Implemented `buildFallbackBody()`** to generate personalized email bodies that:
  - Include editorial summary when available (making emails feel researched)
  - Maintain warm, non-salesy tone
  - Avoid mass-blast language
- **Updated draft generation logic** to use per-lead organization names for subject personalization while respecting database templates when available

### Seed Data Updates (`prisma/seed.ts`)
- **Updated message templates** to use new personalized subject and body formats
- **Aligned templates** with the conversational, research-driven tone across university and high school variants

## Notable Implementation Details
- Subject templates use placeholder syntax (`{city}`, `{org}`, `{season}`) for flexible substitution
- Organization name shortening strips institutional suffixes (University, College, etc.) and applies heuristics for natural phrasing
- Template selection is deterministic (hash-based on org name) to ensure consistency while avoiding identical subjects in bulk outreach
- Greeting resolution handles edge cases where discovery couldn't identify a real contact person
- Fallback body generation conditionally includes editorial summary paragraph only when available, maintaining personalization without forcing generic content

https://claude.ai/code/session_016MH5DgK4csx3mRJSTviwMs