### PR TITLE
Simplify fallback email template and remove editorial summary personalization

### DIFF
--- a/src/lib/discovery/draft-generator.ts
+++ b/src/lib/discovery/draft-generator.ts
@@ -41,21 +41,13 @@ function resolveGreeting(firstName: string, lastName: string | null, organizatio
 
 /**
  * Build the fallback email body template when no MessageTemplate record exists.
- *
- * The body is personalized: if editorialSummary is available for this lead, a
- * paragraph acknowledging what the group does is included, making the email feel
- * researched rather than mass-sent.
  */
-function buildFallbackBody(hasEditorialSummary: boolean): string {
-  const editorialParagraph = hasEditorialSummary
-    ? '\nI came across {{organization}} — {{editorialSummary}} That kind of work is exactly what I love getting to be part of.\n'
-    : ''
-
+function buildFallbackBody(): string {
   return `Hi {{firstName}},
 
 I'm Deke Sharon — I'll be in the {{baseLocation}} area{{availabilityDates}} and wanted to reach out directly.
-${editorialParagraph}
-I work with vocal groups of all kinds on workshops, coaching, and masterclasses. If the timing feels right and there's a good fit, I'd love a quick conversation — no pressure either way.
+
+If you'd like to connect about a workshop or coaching session while I'm in town, I'm game — just say the word.
 
 You can see what I offer at {{servicesLink}}
 
@@ -146,14 +138,13 @@ export async function generateDraftsForCampaign(campaignId: string): Promise<Dra
     }
 
     const greeting = resolveGreeting(cl.lead.firstName, cl.lead.lastName, cl.lead.organization)
-    const hasEditorialSummary = Boolean(cl.lead.editorialSummary?.trim())
 
     // Build subject: per-lead personalization using org name
     let templateSubject = defaultTemplate?.subject
       ?? buildDefaultSubject(campaign.baseLocation, campaign.booking?.serviceType, cl.lead.organization)
 
     // Build body: use DB template if available, otherwise the personalized fallback
-    let templateBody = defaultTemplate?.body ?? buildFallbackBody(hasEditorialSummary)
+    let templateBody = defaultTemplate?.body ?? buildFallbackBody()
 
     const vars: Record<string, string> = {
       firstName: greeting,


### PR DESCRIPTION
## Summary
This PR simplifies the fallback email template generation by removing the editorial summary-based personalization feature. The email body is now more straightforward and consistent, with a single template that doesn't vary based on lead data.

## Key Changes
- Removed `hasEditorialSummary` parameter from `buildFallbackBody()` function, simplifying its signature
- Eliminated the conditional editorial paragraph that was inserted when `editorialSummary` was available
- Updated the email body copy to be more direct and action-oriented ("If you'd like to connect about a workshop or coaching session...")
- Removed the editorial summary check and variable assignment in `generateDraftsForCampaign()`

## Implementation Details
The fallback email template is now static and doesn't require checking for the presence of `editorialSummary` on the lead record. This reduces complexity in the draft generation logic while maintaining the core messaging about workshops and coaching services. The new template language is more conversational and focuses on the call-to-action rather than acknowledging the organization's work.

https://claude.ai/code/session_01Fdd7GwahDPiLHs4sJ8ANiY