### PR TITLE
Add email attachments, CC, and recipient override to drafts

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -571,6 +571,9 @@ model EmailDraft {
   body            String        // Pre-rendered HTML from template
   status          String        @default("DRAFT") // DRAFT, APPROVED, SENT, FAILED
   editedByUser    Boolean       @default(false)
+  overrideEmail   String?       // User-corrected recipient email (used instead of lead.email)
+  ccEmail         String?       // Optional CC recipient
+  attachments     Json?         // JSON array of { filename, path, size } objects
   sentAt          DateTime?
   errorMessage    String?
 

--- a/src/app/api/campaigns/[id]/drafts/[draftId]/attachments/route.ts
+++ b/src/app/api/campaigns/[id]/drafts/[draftId]/attachments/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { Prisma } from '@prisma/client'
+import { prisma } from '@/lib/db'
+import { handleApiError, ApiError } from '@/lib/api-error'
+import { writeFile, mkdir, unlink } from 'fs/promises'
+import path from 'path'
+import type { Attachment } from '@/lib/validations/email-draft'
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB
+const MAX_ATTACHMENTS = 5
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; draftId: string }> }
+) {
+  try {
+    const { id: campaignId, draftId } = await params
+
+    const draft = await prisma.emailDraft.findFirst({
+      where: { id: draftId, campaignId },
+    })
+
+    if (!draft) {
+      throw new ApiError(404, 'Draft not found', 'NOT_FOUND')
+    }
+
+    if (draft.status !== 'DRAFT') {
+      throw new ApiError(400, `Cannot modify attachments for a draft with status ${draft.status}`, 'INVALID_STATUS')
+    }
+
+    const existingAttachments = (draft.attachments as Attachment[] | null) || []
+    if (existingAttachments.length >= MAX_ATTACHMENTS) {
+      throw new ApiError(400, `Maximum ${MAX_ATTACHMENTS} attachments allowed`, 'MAX_ATTACHMENTS')
+    }
+
+    const formData = await request.formData()
+    const file = formData.get('file') as File | null
+
+    if (!file) {
+      throw new ApiError(400, 'No file provided', 'NO_FILE')
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      throw new ApiError(400, 'File size exceeds 10MB limit', 'FILE_TOO_LARGE')
+    }
+
+    // Save file to public/uploads/attachments/<draftId>/
+    const uploadDir = path.join(process.cwd(), 'public', 'uploads', 'attachments', draftId)
+    await mkdir(uploadDir, { recursive: true })
+
+    const safeFilename = file.name.replace(/[^a-zA-Z0-9._-]/g, '_')
+    const filePath = path.join(uploadDir, safeFilename)
+    const relativePath = `/uploads/attachments/${draftId}/${safeFilename}`
+
+    const buffer = Buffer.from(await file.arrayBuffer())
+    await writeFile(filePath, buffer)
+
+    const attachment: Attachment = {
+      filename: file.name,
+      path: relativePath,
+      size: file.size,
+    }
+
+    const updatedAttachments = [...existingAttachments, attachment]
+
+    await prisma.emailDraft.update({
+      where: { id: draftId },
+      data: { attachments: updatedAttachments, editedByUser: true },
+    })
+
+    return NextResponse.json(attachment)
+  } catch (error) {
+    return handleApiError(error)
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; draftId: string }> }
+) {
+  try {
+    const { id: campaignId, draftId } = await params
+    const { filename } = await request.json()
+
+    if (!filename) {
+      throw new ApiError(400, 'Filename is required', 'NO_FILENAME')
+    }
+
+    const draft = await prisma.emailDraft.findFirst({
+      where: { id: draftId, campaignId },
+    })
+
+    if (!draft) {
+      throw new ApiError(404, 'Draft not found', 'NOT_FOUND')
+    }
+
+    if (draft.status !== 'DRAFT') {
+      throw new ApiError(400, `Cannot modify attachments for a draft with status ${draft.status}`, 'INVALID_STATUS')
+    }
+
+    const existingAttachments = (draft.attachments as Attachment[] | null) || []
+    const attachment = existingAttachments.find(a => a.filename === filename)
+
+    if (!attachment) {
+      throw new ApiError(404, 'Attachment not found', 'ATTACHMENT_NOT_FOUND')
+    }
+
+    // Remove file from disk
+    try {
+      const filePath = path.join(process.cwd(), 'public', attachment.path)
+      await unlink(filePath)
+    } catch {
+      // File may already be deleted
+    }
+
+    const updatedAttachments = existingAttachments.filter(a => a.filename !== filename)
+
+    await prisma.emailDraft.update({
+      where: { id: draftId },
+      data: {
+        attachments: updatedAttachments.length > 0 ? updatedAttachments : Prisma.JsonNull,
+        editedByUser: true,
+      },
+    })
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    return handleApiError(error)
+  }
+}

--- a/src/app/api/campaigns/[id]/drafts/[draftId]/route.ts
+++ b/src/app/api/campaigns/[id]/drafts/[draftId]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/db'
 import { handleApiError, ApiError } from '@/lib/api-error'
 import { updateDraftSchema } from '@/lib/validations/email-draft'
@@ -27,7 +28,11 @@ export async function PATCH(
     const updated = await prisma.emailDraft.update({
       where: { id: draftId },
       data: {
-        ...data,
+        subject: data.subject,
+        body: data.body,
+        overrideEmail: data.overrideEmail,
+        ccEmail: data.ccEmail,
+        attachments: data.attachments === null ? Prisma.JsonNull : data.attachments,
         editedByUser: true,
       },
       include: {

--- a/src/app/api/campaigns/[id]/drafts/send/route.ts
+++ b/src/app/api/campaigns/[id]/drafts/send/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { handleApiError, ApiError } from '@/lib/api-error'
-import { sendEmail } from '@/lib/outreach/providers/resend'
-import { sendDraftsSchema } from '@/lib/validations/email-draft'
+import { sendEmail, EmailAttachment } from '@/lib/outreach/providers/resend'
+import { sendDraftsSchema, Attachment } from '@/lib/validations/email-draft'
+import { readFile } from 'fs/promises'
+import path from 'path'
 
 export async function POST(
   request: NextRequest,
@@ -51,12 +53,31 @@ export async function POST(
 
     for (const draft of drafts) {
       try {
+        // Use override email if set, otherwise fall back to lead email
+        const toEmail = draft.overrideEmail || draft.lead.email
+
+        // Build attachments from stored file references
+        const emailAttachments: EmailAttachment[] = []
+        if (draft.attachments && Array.isArray(draft.attachments)) {
+          for (const att of draft.attachments as Attachment[]) {
+            try {
+              const filePath = path.join(process.cwd(), 'public', att.path)
+              const content = await readFile(filePath)
+              emailAttachments.push({ filename: att.filename, content })
+            } catch {
+              // Skip attachments that can't be read
+            }
+          }
+        }
+
         const result = await sendEmail({
-          to: draft.lead.email,
+          to: toEmail,
           subject: draft.subject,
           html: draft.body,
           campaignId,
           leadId: draft.leadId,
+          cc: draft.ccEmail || undefined,
+          attachments: emailAttachments.length > 0 ? emailAttachments : undefined,
         })
 
         if (result.success) {

--- a/src/app/api/campaigns/[id]/generate-drafts/route.ts
+++ b/src/app/api/campaigns/[id]/generate-drafts/route.ts
@@ -12,7 +12,7 @@ export async function POST(
   try {
     const { id: campaignId } = await params
     const body = await request.json()
-    const { leadIds, templateId } = generateDraftsSchema.parse(body)
+    const { leadIds, templateId, force } = generateDraftsSchema.parse(body)
 
     // Verify campaign exists
     const campaign = await prisma.campaign.findUnique({
@@ -61,9 +61,9 @@ export async function POST(
       throw new ApiError(400, 'No matching campaign leads found', 'NO_LEADS')
     }
 
-    // Quality gate: filter out leads that shouldn't receive drafts
+    // Quality gate: filter out leads that shouldn't receive drafts (skip when force=true)
     const genericPrefixes = ['info@', 'hello@', 'contact@', 'admin@', 'office@', 'general@']
-    const draftableLeads = campaignLeads.filter((cl: any) => {
+    const draftableLeads = force ? campaignLeads : campaignLeads.filter((cl: any) => {
       // No placeholder emails
       if (cl.lead.email?.includes('@placeholder.local')) return false
       // No fake "Contact at Org" names from unenriched leads

--- a/src/components/campaigns/drafts-tab.tsx
+++ b/src/components/campaigns/drafts-tab.tsx
@@ -13,7 +13,15 @@ import {
   Trash2,
   FileText,
   Mail,
+  Paperclip,
+  AlertTriangle,
 } from 'lucide-react'
+
+interface AttachmentInfo {
+  filename: string
+  path: string
+  size: number
+}
 
 interface Draft {
   id: string
@@ -21,6 +29,9 @@ interface Draft {
   body: string
   status: string
   editedByUser: boolean
+  overrideEmail: string | null
+  ccEmail: string | null
+  attachments: AttachmentInfo[] | null
   lead: {
     firstName: string
     lastName: string
@@ -54,6 +65,7 @@ export function DraftsTab({ campaignId, campaignLeadIds, onDraftsChange }: Draft
   const [drafts, setDrafts] = useState<Draft[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [isGenerating, setIsGenerating] = useState(false)
+  const [isForceGenerating, setIsForceGenerating] = useState(false)
   const [isSending, setIsSending] = useState(false)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [editingDraft, setEditingDraft] = useState<Draft | null>(null)
@@ -102,6 +114,41 @@ export function DraftsTab({ campaignId, campaignLeadIds, onDraftsChange }: Draft
       setError(err instanceof Error ? err.message : 'Failed to generate drafts')
     } finally {
       setIsGenerating(false)
+    }
+  }
+
+  const handleForceGenerate = async () => {
+    setIsForceGenerating(true)
+    setError(null)
+    try {
+      // Find lead IDs that don't have drafts yet
+      const draftCampaignLeadIds = new Set(drafts.map(d => d.id))
+      const missingLeadIds = campaignLeadIds.filter(id => !draftCampaignLeadIds.has(id))
+
+      if (missingLeadIds.length === 0) return
+
+      const response = await fetch(
+        `/api/campaigns/${campaignId}/generate-drafts`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            leadIds: missingLeadIds,
+            force: true,
+          }),
+        }
+      )
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.error || 'Failed to generate drafts')
+      }
+      setSelectedIds(new Set())
+      await fetchDrafts()
+      onDraftsChange?.()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to generate drafts for skipped leads')
+    } finally {
+      setIsForceGenerating(false)
     }
   }
 
@@ -219,6 +266,7 @@ export function DraftsTab({ campaignId, campaignLeadIds, onDraftsChange }: Draft
   const selectedDraftIds = Array.from(selectedIds).filter((id) =>
     drafts.find((d) => d.id === id && d.status === 'DRAFT')
   )
+  const skippedCount = campaignLeadIds.length - drafts.length
 
   if (isLoading) {
     return (
@@ -237,7 +285,7 @@ export function DraftsTab({ campaignId, campaignLeadIds, onDraftsChange }: Draft
       <div className="flex items-center justify-between gap-4 flex-wrap">
         <Button
           onClick={handleGenerate}
-          disabled={isGenerating || isSending}
+          disabled={isGenerating || isSending || isForceGenerating}
         >
           {isGenerating ? (
             <Loader2 className="h-4 w-4 mr-2 animate-spin" />
@@ -281,6 +329,36 @@ export function DraftsTab({ campaignId, campaignLeadIds, onDraftsChange }: Draft
           </div>
         )}
       </div>
+
+      {/* Skipped leads banner */}
+      {skippedCount > 0 && drafts.length > 0 && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 flex items-start gap-3">
+          <AlertTriangle className="h-5 w-5 text-amber-600 shrink-0 mt-0.5" />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-amber-800">
+              {skippedCount} lead{skippedCount !== 1 ? 's' : ''} skipped
+            </p>
+            <p className="text-xs text-amber-700 mt-0.5">
+              These leads were filtered out due to missing, placeholder, or generic email addresses.
+              You can force-generate drafts for them, then edit the email address before sending.
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            className="shrink-0 border-amber-300 text-amber-800 hover:bg-amber-100"
+            onClick={handleForceGenerate}
+            disabled={isForceGenerating || isGenerating || isSending}
+          >
+            {isForceGenerating ? (
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            ) : (
+              <Sparkles className="h-4 w-4 mr-2" />
+            )}
+            Generate for Skipped
+          </Button>
+        </div>
+      )}
 
       {/* Error display */}
       {error && (
@@ -336,6 +414,9 @@ export function DraftsTab({ campaignId, campaignLeadIds, onDraftsChange }: Draft
               draft.body.length > 100
                 ? draft.body.slice(0, 100) + '...'
                 : draft.body
+            const displayEmail = draft.overrideEmail || draft.lead.email
+            const hasOverride = !!draft.overrideEmail
+            const attachmentCount = draft.attachments?.length || 0
 
             return (
               <Card
@@ -366,15 +447,28 @@ export function DraftsTab({ campaignId, campaignLeadIds, onDraftsChange }: Draft
                         {draft.lead.firstName} {draft.lead.lastName}
                       </span>
                       <span className="text-xs text-muted-foreground truncate">
-                        {draft.lead.email}
+                        {displayEmail}
                       </span>
+                      {hasOverride && (
+                        <Badge variant="outline" className="text-xs bg-blue-50 text-blue-700 border-blue-200">
+                          edited
+                        </Badge>
+                      )}
                     </div>
                     <p className="text-sm font-semibold truncate">
                       {draft.subject}
                     </p>
-                    <p className="text-xs text-muted-foreground line-clamp-2">
-                      {bodyPreview}
-                    </p>
+                    <div className="flex items-center gap-2">
+                      <p className="text-xs text-muted-foreground line-clamp-2 flex-1">
+                        {bodyPreview}
+                      </p>
+                      {attachmentCount > 0 && (
+                        <Badge variant="outline" className="text-xs shrink-0">
+                          <Paperclip className="h-3 w-3 mr-1" />
+                          {attachmentCount}
+                        </Badge>
+                      )}
+                    </div>
                   </div>
 
                   {/* Status + actions */}

--- a/src/components/campaigns/email-draft-editor.tsx
+++ b/src/components/campaigns/email-draft-editor.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -14,7 +14,13 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Badge } from '@/components/ui/badge'
-import { Loader2, Save, Send, PenLine } from 'lucide-react'
+import { Loader2, Save, Send, PenLine, Paperclip, X, Upload } from 'lucide-react'
+
+interface AttachmentInfo {
+  filename: string
+  path: string
+  size: number
+}
 
 interface EmailDraftEditorProps {
   draft: {
@@ -23,6 +29,9 @@ interface EmailDraftEditorProps {
     body: string
     status: string
     editedByUser: boolean
+    overrideEmail: string | null
+    ccEmail: string | null
+    attachments: AttachmentInfo[] | null
     lead: {
       firstName: string
       lastName: string
@@ -36,6 +45,12 @@ interface EmailDraftEditorProps {
   onSave: () => void
 }
 
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
 export function EmailDraftEditor({
   draft,
   campaignId,
@@ -45,24 +60,44 @@ export function EmailDraftEditor({
 }: EmailDraftEditorProps) {
   const [subject, setSubject] = useState(draft.subject)
   const [body, setBody] = useState(draft.body)
+  const [toEmail, setToEmail] = useState(draft.overrideEmail || draft.lead.email)
+  const [ccEmail, setCcEmail] = useState(draft.ccEmail || '')
+  const [attachments, setAttachments] = useState<AttachmentInfo[]>(draft.attachments || [])
   const [isSaving, setIsSaving] = useState(false)
   const [isSending, setIsSending] = useState(false)
+  const [isUploading, setIsUploading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const isSent = draft.status === 'SENT'
   const isEdited = draft.editedByUser
-  const hasChanges = subject !== draft.subject || body !== draft.body
+  const originalToEmail = draft.overrideEmail || draft.lead.email
+  const hasChanges =
+    subject !== draft.subject ||
+    body !== draft.body ||
+    toEmail !== originalToEmail ||
+    ccEmail !== (draft.ccEmail || '') ||
+    JSON.stringify(attachments) !== JSON.stringify(draft.attachments || [])
 
   const handleSave = async () => {
     setIsSaving(true)
     setError(null)
     try {
+      // Determine if email was changed from lead's original
+      const overrideEmail = toEmail !== draft.lead.email ? toEmail : null
+
       const response = await fetch(
         `/api/campaigns/${campaignId}/drafts/${draft.id}`,
         {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ subject, body }),
+          body: JSON.stringify({
+            subject,
+            body,
+            overrideEmail,
+            ccEmail: ccEmail || null,
+            attachments: attachments.length > 0 ? attachments : null,
+          }),
         }
       )
       if (!response.ok) {
@@ -84,12 +119,19 @@ export function EmailDraftEditor({
     try {
       // Save any pending changes first
       if (hasChanges) {
+        const overrideEmail = toEmail !== draft.lead.email ? toEmail : null
         const saveResponse = await fetch(
           `/api/campaigns/${campaignId}/drafts/${draft.id}`,
           {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ subject, body }),
+            body: JSON.stringify({
+              subject,
+              body,
+              overrideEmail,
+              ccEmail: ccEmail || null,
+              attachments: attachments.length > 0 ? attachments : null,
+            }),
           }
         )
         if (!saveResponse.ok) {
@@ -118,11 +160,61 @@ export function EmailDraftEditor({
     }
   }
 
-  const isProcessing = isSaving || isSending
+  const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    setIsUploading(true)
+    setError(null)
+    try {
+      const formData = new FormData()
+      formData.append('file', file)
+
+      const response = await fetch(
+        `/api/campaigns/${campaignId}/drafts/${draft.id}/attachments`,
+        { method: 'POST', body: formData }
+      )
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.error || 'Failed to upload file')
+      }
+      const attachment: AttachmentInfo = await response.json()
+      setAttachments((prev) => [...prev, attachment])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to upload file')
+    } finally {
+      setIsUploading(false)
+      // Reset file input
+      if (fileInputRef.current) fileInputRef.current.value = ''
+    }
+  }
+
+  const handleRemoveAttachment = async (filename: string) => {
+    setError(null)
+    try {
+      const response = await fetch(
+        `/api/campaigns/${campaignId}/drafts/${draft.id}/attachments`,
+        {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ filename }),
+        }
+      )
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.error || 'Failed to remove attachment')
+      }
+      setAttachments((prev) => prev.filter((a) => a.filename !== filename))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to remove attachment')
+    }
+  }
+
+  const isProcessing = isSaving || isSending || isUploading
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-2xl">
+      <DialogContent className="sm:max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <div className="flex items-center gap-3">
             <DialogTitle>
@@ -147,12 +239,43 @@ export function EmailDraftEditor({
             )}
           </div>
           <DialogDescription>
-            {draft.lead.email}
-            {draft.lead.organization && ` - ${draft.lead.organization}`}
+            {draft.lead.organization || draft.lead.email}
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4 py-2">
+          {/* To Email */}
+          <div className="space-y-2">
+            <Label htmlFor="draft-to-email">To</Label>
+            <Input
+              id="draft-to-email"
+              type="email"
+              value={toEmail}
+              onChange={(e) => setToEmail(e.target.value)}
+              disabled={isSent || isProcessing}
+              placeholder="Recipient email address"
+            />
+            {toEmail !== draft.lead.email && (
+              <p className="text-xs text-amber-600">
+                Original lead email: {draft.lead.email}
+              </p>
+            )}
+          </div>
+
+          {/* CC Email */}
+          <div className="space-y-2">
+            <Label htmlFor="draft-cc-email">CC (optional)</Label>
+            <Input
+              id="draft-cc-email"
+              type="email"
+              value={ccEmail}
+              onChange={(e) => setCcEmail(e.target.value)}
+              disabled={isSent || isProcessing}
+              placeholder="CC email address"
+            />
+          </div>
+
+          {/* Subject */}
           <div className="space-y-2">
             <Label htmlFor="draft-subject">Subject</Label>
             <Input
@@ -164,6 +287,7 @@ export function EmailDraftEditor({
             />
           </div>
 
+          {/* Body */}
           <div className="space-y-2">
             <Label htmlFor="draft-body">Body</Label>
             <Textarea
@@ -175,6 +299,65 @@ export function EmailDraftEditor({
               className="font-mono text-sm resize-none"
               placeholder="Email body content"
             />
+          </div>
+
+          {/* Attachments */}
+          <div className="space-y-2">
+            <Label>Attachments</Label>
+            {attachments.length > 0 && (
+              <div className="space-y-1">
+                {attachments.map((att) => (
+                  <div
+                    key={att.filename}
+                    className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
+                  >
+                    <Paperclip className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                    <span className="truncate flex-1">{att.filename}</span>
+                    <span className="text-xs text-muted-foreground shrink-0">
+                      {formatFileSize(att.size)}
+                    </span>
+                    {!isSent && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6 text-muted-foreground hover:text-destructive"
+                        onClick={() => handleRemoveAttachment(att.filename)}
+                        disabled={isProcessing}
+                      >
+                        <X className="h-3.5 w-3.5" />
+                      </Button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+            {!isSent && attachments.length < 5 && (
+              <div>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  onChange={handleFileUpload}
+                  className="hidden"
+                  disabled={isProcessing}
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={isProcessing}
+                >
+                  {isUploading ? (
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  ) : (
+                    <Upload className="h-4 w-4 mr-2" />
+                  )}
+                  {isUploading ? 'Uploading...' : 'Add Attachment'}
+                </Button>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Max 10MB per file, up to 5 attachments
+                </p>
+              </div>
+            )}
           </div>
 
           {error && (

--- a/src/lib/outreach/providers/resend.ts
+++ b/src/lib/outreach/providers/resend.ts
@@ -1,11 +1,18 @@
 import { Resend } from 'resend'
 
+export interface EmailAttachment {
+  filename: string
+  content: Buffer
+}
+
 export interface SendEmailParams {
   to: string
   subject: string
   html: string
   campaignId: string
   leadId: string
+  cc?: string
+  attachments?: EmailAttachment[]
 }
 
 export interface EmailResponse {
@@ -45,6 +52,10 @@ export async function sendEmail(params: SendEmailParams): Promise<EmailResponse>
       to: params.to,
       subject: params.subject,
       html: params.html,
+      ...(params.cc ? { cc: [params.cc] } : {}),
+      ...(params.attachments && params.attachments.length > 0
+        ? { attachments: params.attachments }
+        : {}),
       tags: [
         {
           name: 'campaignId',

--- a/src/lib/validations/email-draft.ts
+++ b/src/lib/validations/email-draft.ts
@@ -3,11 +3,21 @@ import { z } from 'zod'
 export const generateDraftsSchema = z.object({
   leadIds: z.array(z.string().min(1)).min(1, 'At least one lead ID is required'),
   templateId: z.string().min(1).optional(),
+  force: z.boolean().optional(),
+})
+
+export const attachmentSchema = z.object({
+  filename: z.string().min(1),
+  path: z.string().min(1),
+  size: z.number().nonnegative(),
 })
 
 export const updateDraftSchema = z.object({
   subject: z.string().min(1).optional(),
   body: z.string().min(1).optional(),
+  overrideEmail: z.string().email().optional().nullable(),
+  ccEmail: z.string().email().optional().nullable(),
+  attachments: z.array(attachmentSchema).optional().nullable(),
 })
 
 export const sendDraftsSchema = z.object({
@@ -17,3 +27,4 @@ export const sendDraftsSchema = z.object({
 export type GenerateDraftsInput = z.infer<typeof generateDraftsSchema>
 export type UpdateDraftInput = z.infer<typeof updateDraftSchema>
 export type SendDraftsInput = z.infer<typeof sendDraftsSchema>
+export type Attachment = z.infer<typeof attachmentSchema>


### PR DESCRIPTION
## Summary
This PR extends the email draft editor with support for file attachments, CC recipients, and the ability to override the recipient email address before sending. These features enable more flexible email customization while maintaining the ability to track changes made by users.

## Key Changes

- **Attachment Management**: Added file upload/download functionality with a new API endpoint (`/api/campaigns/[id]/drafts/[draftId]/attachments`) that handles POST (upload) and DELETE (remove) operations. Files are stored in `public/uploads/attachments/` with a 10MB per-file limit and maximum 5 attachments per draft.

- **Email Recipient Override**: Users can now modify the "To" email address in the draft editor, with the original lead email displayed as a reference. The system stores the override in the `overrideEmail` field and uses it when sending if different from the lead's original email.

- **CC Support**: Added optional CC email field to drafts, stored in the `ccEmail` field and passed to the email provider when sending.

- **UI Enhancements**:
  - Updated draft editor dialog with new input fields for To, CC, and attachments
  - Added attachment display with file size formatting and removal capability
  - Added visual indicators in the drafts list showing edited status and attachment count
  - Added "Generate for Skipped" button to force-generate drafts for leads that were filtered out

- **Database Schema**: Extended `EmailDraft` model with `overrideEmail`, `ccEmail`, and `attachments` fields to persist these new properties.

- **Email Sending**: Modified the send endpoint to use override email when available and include attachments and CC in the actual email sent via Resend provider.

- **Validation**: Updated Zod schemas to validate the new email and attachment fields, including email format validation and nullable handling.

## Notable Implementation Details

- File uploads are sanitized to prevent directory traversal attacks
- Attachments are stored with draft ID in the path for organization and cleanup
- The `editedByUser` flag is set to true when attachments are added/removed
- Change detection includes all new fields (email, CC, attachments) to properly track modifications
- Sent drafts cannot have attachments modified, maintaining immutability of sent messages

https://claude.ai/code/session_01CGkF6NDbcobrJTQ8nUiE1n