### PR TITLE
feat: verify campaign email send status via Resend API

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -536,13 +536,14 @@ model OutreachLog {
   campaignLeadId  String
   campaign        Campaign        @relation(fields: [campaignId], references: [id], onDelete: Cascade)
   campaignId      String
-  channel         String          // EMAIL, SMS, LINKEDIN
-  status          String          @default("PENDING") // PENDING, SENT, DELIVERED, OPENED, CLICKED, RESPONDED, FAILED, BOUNCED
-  sentAt          DateTime?
-  openedAt        DateTime?
-  clickedAt       DateTime?
-  respondedAt     DateTime?
-  errorMessage    String?
+  channel           String          // EMAIL, SMS, LINKEDIN
+  status            String          @default("PENDING") // PENDING, SENT, DELIVERED, OPENED, CLICKED, RESPONDED, FAILED, BOUNCED
+  providerMessageId String?         // Resend email ID for status verification
+  sentAt            DateTime?
+  openedAt          DateTime?
+  clickedAt         DateTime?
+  respondedAt       DateTime?
+  errorMessage      String?
   createdAt       DateTime        @default(now())
   updatedAt       DateTime        @updatedAt
 

--- a/src/app/api/campaigns/[id]/drafts/send/route.ts
+++ b/src/app/api/campaigns/[id]/drafts/send/route.ts
@@ -86,7 +86,7 @@ export async function POST(
             data: { status: 'SENT', sentAt: new Date() },
           })
 
-          // Create outreach log
+          // Create outreach log with Resend message ID for verification
           await prisma.outreachLog.create({
             data: {
               campaignLeadId: draft.campaignLeadId,
@@ -94,6 +94,7 @@ export async function POST(
               channel: 'EMAIL',
               status: 'SENT',
               sentAt: new Date(),
+              providerMessageId: result.id || null,
             },
           })
 

--- a/src/app/api/campaigns/[id]/verify-emails/route.ts
+++ b/src/app/api/campaigns/[id]/verify-emails/route.ts
@@ -1,0 +1,116 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { Resend } from 'resend'
+import { prisma } from '@/lib/db'
+import { handleApiError, ApiError } from '@/lib/api-error'
+
+type Params = {
+  params: Promise<{ id: string }>
+}
+
+// POST /api/campaigns/[id]/verify-emails
+// Queries Resend for the latest delivery status of sent emails and updates OutreachLog records
+export async function POST(request: NextRequest, { params }: Params) {
+  try {
+    const { id: campaignId } = await params
+
+    const apiKey = process.env.RESEND_API_KEY
+    if (!apiKey) {
+      throw new ApiError(500, 'RESEND_API_KEY is not configured', 'MISSING_CONFIG')
+    }
+
+    const campaign = await prisma.campaign.findUnique({ where: { id: campaignId } })
+    if (!campaign) {
+      throw new ApiError(404, 'Campaign not found', 'NOT_FOUND')
+    }
+
+    // Fetch outreach logs for this campaign that have a provider message ID
+    const logs = await prisma.outreachLog.findMany({
+      where: {
+        campaignId,
+        channel: 'EMAIL',
+        providerMessageId: { not: null },
+      },
+    })
+
+    if (logs.length === 0) {
+      return NextResponse.json({ verified: 0, updated: 0, message: 'No verifiable emails found' })
+    }
+
+    const resend = new Resend(apiKey)
+
+    const STATUS_RANK: Record<string, number> = {
+      PENDING: 0,
+      SENT: 1,
+      DELIVERED: 2,
+      OPENED: 3,
+      CLICKED: 4,
+      RESPONDED: 5,
+      BOUNCED: 6,
+      FAILED: 7,
+    }
+
+    // Map Resend's last_event to our status
+    function mapResendStatus(lastEvent: string): string {
+      switch (lastEvent) {
+        case 'delivered':
+          return 'DELIVERED'
+        case 'opened':
+          return 'OPENED'
+        case 'clicked':
+          return 'CLICKED'
+        case 'bounced':
+        case 'delivery_delayed':
+          return 'BOUNCED'
+        case 'complained':
+        case 'failed':
+          return 'FAILED'
+        default:
+          return 'SENT'
+      }
+    }
+
+    let updated = 0
+
+    for (const log of logs) {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { data, error } = await (resend.emails as any).get(log.providerMessageId!)
+
+        if (error || !data) continue
+
+        const newStatus = mapResendStatus(data.last_event || '')
+
+        // Only update if the new status is "higher" than current (avoid regressing)
+        const currentRank = STATUS_RANK[log.status] ?? 0
+        const newRank = STATUS_RANK[newStatus] ?? 0
+
+        if (newRank <= currentRank) continue
+
+        const updateData: Record<string, unknown> = { status: newStatus }
+
+        if (newStatus === 'DELIVERED' && !log.sentAt) {
+          updateData.sentAt = new Date()
+        }
+        if (newStatus === 'OPENED' && !log.openedAt && data.opened_at) {
+          updateData.openedAt = new Date(data.opened_at)
+        }
+        if (newStatus === 'CLICKED' && !log.clickedAt && data.clicked_at) {
+          updateData.clickedAt = new Date(data.clicked_at)
+        }
+
+        await prisma.outreachLog.update({
+          where: { id: log.id },
+          data: updateData,
+        })
+
+        updated++
+      } catch {
+        // Skip individual lookup failures — Resend may not have data yet
+      }
+    }
+
+    return NextResponse.json({ verified: logs.length, updated })
+  } catch (error) {
+    return handleApiError(error)
+  }
+}

--- a/src/app/api/email-drafts/send/route.ts
+++ b/src/app/api/email-drafts/send/route.ts
@@ -49,7 +49,7 @@ export async function POST(request: NextRequest) {
             data: { status: 'SENT', sentAt: new Date() },
           })
 
-          // Create outreach log
+          // Create outreach log with Resend message ID for verification
           await prisma.outreachLog.create({
             data: {
               campaignLeadId: draft.campaignLeadId,
@@ -57,6 +57,7 @@ export async function POST(request: NextRequest) {
               channel: 'EMAIL',
               status: 'SENT',
               sentAt: new Date(),
+              providerMessageId: result.id || null,
             },
           })
 

--- a/src/app/dashboard/campaigns/[id]/page.tsx
+++ b/src/app/dashboard/campaigns/[id]/page.tsx
@@ -941,6 +941,7 @@ export default function CampaignDetailPage({
 
         <TabsContent value="messages">
           <MessagesTab
+            campaignId={campaign.id}
             outreachLogs={campaign.leads.flatMap(cl =>
               cl.outreachLogs.map(ol => ({
                 ...ol,
@@ -948,6 +949,7 @@ export default function CampaignDetailPage({
                 leadEmail: cl.lead.email
               }))
             )}
+            onRefresh={fetchCampaign}
           />
         </TabsContent>
 

--- a/src/components/campaigns/messages-tab.tsx
+++ b/src/components/campaigns/messages-tab.tsx
@@ -3,10 +3,12 @@
 import { useState } from 'react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
 import { MessageCard } from './message-card'
-import { Mail } from 'lucide-react'
+import { Mail, RefreshCw } from 'lucide-react'
 
 interface MessagesTabProps {
+  campaignId: string
   outreachLogs: Array<{
     id: string
     channel: string
@@ -19,11 +21,14 @@ interface MessagesTabProps {
     leadName: string
     leadEmail: string
   }>
+  onRefresh?: () => void
 }
 
-export function MessagesTab({ outreachLogs }: MessagesTabProps) {
+export function MessagesTab({ campaignId, outreachLogs, onRefresh }: MessagesTabProps) {
   const [channelFilter, setChannelFilter] = useState('ALL')
   const [statusFilter, setStatusFilter] = useState('ALL')
+  const [isVerifying, setIsVerifying] = useState(false)
+  const [verifyResult, setVerifyResult] = useState<{ verified: number; updated: number } | null>(null)
 
   const filtered = outreachLogs.filter(log => {
     if (channelFilter !== 'ALL' && log.channel !== channelFilter) return false
@@ -41,6 +46,23 @@ export function MessagesTab({ outreachLogs }: MessagesTabProps) {
     return acc
   }, {} as Record<string, typeof outreachLogs>)
 
+  const handleVerify = async () => {
+    setIsVerifying(true)
+    setVerifyResult(null)
+    try {
+      const res = await fetch(`/api/campaigns/${campaignId}/verify-emails`, { method: 'POST' })
+      const data = await res.json()
+      setVerifyResult(data)
+      if (data.updated > 0) {
+        onRefresh?.()
+      }
+    } catch {
+      setVerifyResult({ verified: 0, updated: 0 })
+    } finally {
+      setIsVerifying(false)
+    }
+  }
+
   if (outreachLogs.length === 0) {
     return (
       <Card>
@@ -57,8 +79,8 @@ export function MessagesTab({ outreachLogs }: MessagesTabProps) {
 
   return (
     <div className="space-y-6">
-      {/* Filters */}
-      <div className="flex gap-4">
+      {/* Filters + Verify */}
+      <div className="flex gap-4 items-center flex-wrap">
         <Select value={channelFilter} onValueChange={setChannelFilter}>
           <SelectTrigger className="w-[180px]">
             <SelectValue />
@@ -84,6 +106,25 @@ export function MessagesTab({ outreachLogs }: MessagesTabProps) {
             <SelectItem value="FAILED">Failed</SelectItem>
           </SelectContent>
         </Select>
+
+        <div className="ml-auto flex items-center gap-3">
+          {verifyResult && (
+            <p className="text-sm text-muted-foreground">
+              {verifyResult.updated > 0
+                ? `Updated ${verifyResult.updated} of ${verifyResult.verified} emails`
+                : `All ${verifyResult.verified} emails already up to date`}
+            </p>
+          )}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleVerify}
+            disabled={isVerifying}
+          >
+            <RefreshCw className={`h-4 w-4 mr-2 ${isVerifying ? 'animate-spin' : ''}`} />
+            {isVerifying ? 'Verifying…' : 'Verify Send Status'}
+          </Button>
+        </div>
       </div>
 
       {/* Grouped messages */}

--- a/src/lib/outreach/queue.ts
+++ b/src/lib/outreach/queue.ts
@@ -94,7 +94,7 @@ export async function processOutreachQueue(
         continue
       }
 
-      // Create OutreachLog entry
+      // Create OutreachLog entry with provider message ID for verification
       await prisma.outreachLog.create({
         data: {
           campaignLeadId: job.campaignLeadId,
@@ -103,6 +103,7 @@ export async function processOutreachQueue(
           status: providerResult.success ? 'SENT' : 'FAILED',
           sentAt: providerResult.success ? new Date() : null,
           errorMessage: providerResult.error,
+          providerMessageId: providerResult.success ? (providerResult.id || null) : null,
         },
       })
 


### PR DESCRIPTION
- Add providerMessageId field to OutreachLog to store the Resend email ID
- Store Resend email ID when creating OutreachLog entries in all send paths
- Add POST /api/campaigns/[id]/verify-emails endpoint that queries Resend
  for real-time delivery status and updates OutreachLog records
- Add "Verify Send Status" button to the Messages tab UI with live feedback

https://claude.ai/code/session_01Bd99BoMfd8EoiJoRi7KTLW