### PR TITLE
Add failed draft retry and campaign launch improvements

### DIFF
--- a/src/app/api/campaigns/[id]/drafts/[draftId]/route.ts
+++ b/src/app/api/campaigns/[id]/drafts/[draftId]/route.ts
@@ -21,7 +21,7 @@ export async function PATCH(
       throw new ApiError(404, 'Draft not found', 'NOT_FOUND')
     }
 
-    if (draft.status !== 'DRAFT') {
+    if (draft.status !== 'DRAFT' && draft.status !== 'FAILED') {
       throw new ApiError(400, `Cannot edit a draft with status ${draft.status}`, 'INVALID_STATUS')
     }
 
@@ -34,6 +34,8 @@ export async function PATCH(
         ccEmail: data.ccEmail,
         attachments: data.attachments === null ? Prisma.JsonNull : data.attachments,
         editedByUser: true,
+        // Reset FAILED drafts back to DRAFT so they can be re-sent
+        ...(draft.status === 'FAILED' ? { status: 'DRAFT', errorMessage: null } : {}),
       },
       include: {
         lead: {
@@ -68,7 +70,7 @@ export async function DELETE(
       throw new ApiError(404, 'Draft not found', 'NOT_FOUND')
     }
 
-    if (draft.status !== 'DRAFT') {
+    if (draft.status !== 'DRAFT' && draft.status !== 'FAILED') {
       throw new ApiError(400, `Cannot delete a draft with status ${draft.status}`, 'INVALID_STATUS')
     }
 

--- a/src/app/api/campaigns/[id]/launch/route.ts
+++ b/src/app/api/campaigns/[id]/launch/route.ts
@@ -46,19 +46,11 @@ export async function POST(
     }
 
     // Validate campaign can be launched
-    if (campaign.status !== 'APPROVED') {
+    if (campaign.status !== 'APPROVED' && campaign.status !== 'READY') {
       throw new ApiError(
         400,
-        'Only approved campaigns can be launched',
+        'Only approved or ready campaigns can be launched',
         'INVALID_STATUS'
-      )
-    }
-
-    if (!campaign.approvedAt) {
-      throw new ApiError(
-        400,
-        'Campaign must be approved before launching',
-        'NOT_APPROVED'
       )
     }
 

--- a/src/app/api/campaigns/[id]/resend-failed/route.ts
+++ b/src/app/api/campaigns/[id]/resend-failed/route.ts
@@ -13,13 +13,31 @@ export async function POST(
     const { id: campaignId } = await params
     const body = await request.json().catch(() => ({}))
     // draftIds: resend specific failed drafts; if omitted, resend all failed drafts
-    const draftIds: string[] | undefined = body.draftIds
+    // logIds: OutreachLog IDs (from Messages tab) — resolved to draft IDs via CampaignLead
+    let draftIds: string[] | undefined = body.draftIds
+    const logIds: string[] | undefined = body.logIds
 
     const campaign = await prisma.campaign.findUnique({
       where: { id: campaignId },
     })
     if (!campaign) {
       throw new ApiError(404, 'Campaign not found', 'NOT_FOUND')
+    }
+
+    // Resolve OutreachLog IDs → draft IDs via their CampaignLead
+    if (logIds && logIds.length > 0 && (!draftIds || draftIds.length === 0)) {
+      const logs = await prisma.outreachLog.findMany({
+        where: { id: { in: logIds }, campaignId },
+        select: { campaignLeadId: true },
+      })
+      const campaignLeadIds = logs.map(l => l.campaignLeadId)
+      if (campaignLeadIds.length > 0) {
+        const drafts = await prisma.emailDraft.findMany({
+          where: { campaignId, campaignLeadId: { in: campaignLeadIds }, status: 'FAILED' },
+          select: { id: true },
+        })
+        draftIds = drafts.map(d => d.id)
+      }
     }
 
     // Find failed EmailDraft records (these are the canonical source of truth for failures)

--- a/src/app/dashboard/campaigns/[id]/page.tsx
+++ b/src/app/dashboard/campaigns/[id]/page.tsx
@@ -175,7 +175,9 @@ export default function CampaignDetailPage({
       const result = await response.json();
 
       // Show success message with details
-      alert(`Campaign launched! Sent: ${result.sent}, Failed: ${result.failed}`);
+      const sent = result.outreach?.sent ?? result.sent ?? 0;
+      const failed = result.outreach?.failed ?? result.failed ?? 0;
+      alert(`Campaign launched! Sent: ${sent}, Failed: ${failed}`);
 
       // Refresh campaign data to show new status and outreach logs
       await fetchCampaign();

--- a/src/components/campaigns/drafts-tab.tsx
+++ b/src/components/campaigns/drafts-tab.tsx
@@ -33,6 +33,7 @@ interface Draft {
   overrideEmail: string | null
   ccEmail: string | null
   attachments: AttachmentInfo[] | null
+  errorMessage: string | null
   lead: {
     firstName: string
     lastName: string
@@ -525,6 +526,11 @@ export function DraftsTab({ campaignId, campaignLeadIds, onDraftsChange }: Draft
                         </Badge>
                       )}
                     </div>
+                    {draft.status === 'FAILED' && draft.errorMessage && (
+                      <p className="text-xs text-red-600 mt-1">
+                        Error: {draft.errorMessage}
+                      </p>
+                    )}
                   </div>
 
                   {/* Status + actions */}

--- a/src/components/campaigns/email-draft-editor.tsx
+++ b/src/components/campaigns/email-draft-editor.tsx
@@ -32,6 +32,7 @@ interface EmailDraftEditorProps {
     overrideEmail: string | null
     ccEmail: string | null
     attachments: AttachmentInfo[] | null
+    errorMessage?: string | null
     lead: {
       firstName: string
       lastName: string
@@ -244,6 +245,15 @@ export function EmailDraftEditor({
         </DialogHeader>
 
         <div className="space-y-4 py-2">
+          {/* Previous send error */}
+          {draft.status === 'FAILED' && draft.errorMessage && (
+            <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+              <p className="font-medium">Previous send failed</p>
+              <p className="mt-0.5 text-red-700">{draft.errorMessage}</p>
+              <p className="mt-1 text-xs text-red-600">Edit the draft and save to retry.</p>
+            </div>
+          )}
+
           {/* To Email */}
           <div className="space-y-2">
             <Label htmlFor="draft-to-email">To</Label>


### PR DESCRIPTION
## Summary
This PR enhances the campaign management system by enabling users to retry failed email drafts and improving the campaign launch workflow. It adds support for resending failed drafts via OutreachLog IDs, allows editing and relaunching of failed drafts, and relaxes campaign status requirements for launching.

## Key Changes

- **Failed Draft Retry Support**: Added ability to resend failed drafts by resolving OutreachLog IDs to draft IDs via CampaignLead relationships in the resend-failed endpoint
- **Failed Draft Editing**: Modified draft PATCH and DELETE endpoints to allow editing/deleting drafts with FAILED status, automatically resetting them to DRAFT status when edited
- **Campaign Launch Status**: Updated launch validation to accept both APPROVED and READY campaign statuses, removing the separate `approvedAt` check
- **Error Message Display**: Added error message display in the email draft editor UI to show previous send failures
- **Draft List Error Display**: Enhanced drafts tab to show error messages for failed drafts in the list view
- **Response Handling**: Improved campaign launch response handling to support both old and new response formats for sent/failed counts

## Implementation Details

- OutreachLog → draft ID resolution queries the database to find associated CampaignLeads and their failed EmailDrafts
- Failed drafts are automatically reset to DRAFT status with cleared error messages when edited by users
- Error messages are now persisted and displayed throughout the UI to help users understand why sends failed
- Campaign launch endpoint now accepts READY status in addition to APPROVED, simplifying the approval workflow

https://claude.ai/code/session_01L4vdNnqri2w2u6UVr45AM6