### PR TITLE
Add organization type classification and editorial summaries to leads

### DIFF
--- a/src/app/api/campaigns/[id]/route.ts
+++ b/src/app/api/campaigns/[id]/route.ts
@@ -33,6 +33,7 @@ export async function GET(
                 organization: true,
                 contactTitle: true,
                 website: true,
+                editorialSummary: true,
               }
             },
             outreachLogs: true,

--- a/src/app/dashboard/campaigns/[id]/page.tsx
+++ b/src/app/dashboard/campaigns/[id]/page.tsx
@@ -75,6 +75,7 @@ interface Campaign {
       emailVerified?: boolean;
       needsEnrichment?: boolean;
       website: string | null;
+      editorialSummary: string | null;
     };
     outreachLogs: Array<{
       id: string;

--- a/src/components/campaigns/leads-table-selectable.tsx
+++ b/src/components/campaigns/leads-table-selectable.tsx
@@ -20,7 +20,8 @@ import {
   SheetTitle,
   SheetDescription,
 } from '@/components/ui/sheet'
-import { ArrowUpDown, UserMinus, UserPlus, CheckCircle, AlertCircle, ExternalLink, Phone, Mail, Globe, Building2, MapPin, Star, RotateCw } from 'lucide-react'
+import { ArrowUpDown, UserMinus, UserPlus, CheckCircle, AlertCircle, ExternalLink, Phone, Mail, Globe, Building2, MapPin, Star, RotateCw, Tag } from 'lucide-react'
+import { classifyOrganization, getOrgTypeLabel } from '@/lib/discovery/org-classifier'
 
 interface CampaignLead {
   id: string
@@ -41,6 +42,7 @@ interface CampaignLead {
     score: number
     emailVerified?: boolean
     needsEnrichment?: boolean
+    editorialSummary: string | null
   }
   outreachLogs: Array<{
     id: string
@@ -149,6 +151,8 @@ export function LeadsTableSelectable({ leads, campaignId, onSelectionChange, onL
         const displayName = isPlaceholderName ? null : `${lead.firstName} ${lead.lastName}`
         const primaryLabel = lead.organization || displayName || 'Unknown'
         const secondaryLabel = lead.organization && displayName ? displayName : null
+        const orgType = lead.organization ? classifyOrganization(lead.organization) : 'UNKNOWN'
+        const styleLabel = orgType !== 'UNKNOWN' ? getOrgTypeLabel(orgType) : null
 
         return (
           <button
@@ -168,6 +172,16 @@ export function LeadsTableSelectable({ leads, campaignId, onSelectionChange, onL
             {(secondaryLabel || lead.contactTitle) && (
               <span className="text-[11px] text-muted-foreground block truncate max-w-[180px]">
                 {secondaryLabel}{secondaryLabel && lead.contactTitle ? ' · ' : ''}{lead.contactTitle || ''}
+              </span>
+            )}
+            {styleLabel && (
+              <span className="text-[10px] text-muted-foreground/80 block truncate max-w-[180px]">
+                {styleLabel}
+              </span>
+            )}
+            {lead.editorialSummary && (
+              <span className="text-[10px] text-muted-foreground/80 block truncate max-w-[220px] italic">
+                {lead.editorialSummary}
               </span>
             )}
           </button>
@@ -411,6 +425,33 @@ export function LeadsTableSelectable({ leads, campaignId, onSelectionChange, onL
                       <p className="text-xs text-muted-foreground">Organization</p>
                       <p className="font-medium text-sm">{previewLead.lead.organization}</p>
                     </div>
+                  </div>
+                )}
+
+                {/* Group Style / Type */}
+                {(() => {
+                  const orgType = previewLead.lead.organization
+                    ? classifyOrganization(previewLead.lead.organization)
+                    : 'UNKNOWN'
+                  if (orgType === 'UNKNOWN') return null
+                  return (
+                    <div className="flex items-start gap-3">
+                      <Tag className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
+                      <div>
+                        <p className="text-xs text-muted-foreground">Style</p>
+                        <p className="font-medium text-sm">{getOrgTypeLabel(orgType)}</p>
+                      </div>
+                    </div>
+                  )
+                })()}
+
+                {/* Blurb / About */}
+                {previewLead.lead.editorialSummary && (
+                  <div className="rounded-md border bg-muted/40 px-3 py-2">
+                    <p className="text-xs text-muted-foreground mb-1">About</p>
+                    <p className="text-sm italic leading-snug">
+                      {previewLead.lead.editorialSummary}
+                    </p>
                   </div>
                 )}
 

--- a/src/lib/discovery/org-classifier.ts
+++ b/src/lib/discovery/org-classifier.ts
@@ -251,3 +251,45 @@ export function getSimilarOrgKeywords(orgType: OrgType): string[] {
   const pattern = ORG_PATTERNS.find((p) => p.type === orgType)
   return pattern ? pattern.keywords : []
 }
+
+const ORG_TYPE_LABELS: Record<OrgType, string> = {
+  UNIVERSITY: 'University',
+  COLLEGE: 'College',
+  HIGH_SCHOOL: 'High School',
+  MIDDLE_SCHOOL: 'Middle School',
+  ELEMENTARY_SCHOOL: 'Elementary School',
+  THEATRE: 'Theatre',
+  THEATER: 'Theater',
+  CHOIR: 'Choir',
+  BARBERSHOP: 'Barbershop',
+  A_CAPPELLA_GROUP: 'A Cappella Group',
+  GOSPEL_CHOIR: 'Gospel Choir',
+  COMMUNITY_CHORUS: 'Community Chorus',
+  YOUTH_CHOIR: 'Youth Choir',
+  CHURCH: 'Church',
+  SYNAGOGUE: 'Synagogue',
+  TEMPLE: 'Temple',
+  MOSQUE: 'Mosque',
+  COMMUNITY_CENTER: 'Community Center',
+  ARTS_CENTER: 'Arts Center',
+  MUSIC_SCHOOL: 'Music School',
+  CONSERVATORY: 'Conservatory',
+  PERFORMING_ARTS: 'Performing Arts',
+  FESTIVAL: 'Festival',
+  CONFERENCE: 'Conference',
+  CONVENTION: 'Convention',
+  CORPORATE: 'Corporate',
+  NONPROFIT: 'Nonprofit',
+  UNKNOWN: 'Music Organization',
+}
+
+/**
+ * Get a human-friendly label for an organization type.
+ *
+ * @example
+ * getOrgTypeLabel('HIGH_SCHOOL') // 'High School'
+ * getOrgTypeLabel('A_CAPPELLA_GROUP') // 'A Cappella Group'
+ */
+export function getOrgTypeLabel(orgType: OrgType): string {
+  return ORG_TYPE_LABELS[orgType] ?? 'Music Organization'
+}


### PR DESCRIPTION
## Summary
This PR enhances the leads table by displaying organization type classifications and editorial summaries for each lead. It adds visual indicators showing the style/type of organization and displays curated summaries about organizations in both the table view and the detailed preview panel.

## Key Changes
- **Organization Type Display**: Integrated `classifyOrganization()` and `getOrgTypeLabel()` functions to show human-readable organization types (e.g., "University", "A Cappella Group") in the leads table
- **Editorial Summaries**: Added support for displaying `editorialSummary` field in both the compact table view and the detailed preview panel
- **New Label Mapping**: Created `getOrgTypeLabel()` function in `org-classifier.ts` that maps organization type enums to user-friendly labels
- **API Updates**: Extended the campaign API endpoint to include `editorialSummary` in the lead data response
- **UI Enhancements**: 
  - Added organization type badge in the table row with truncation
  - Added italic editorial summary text in the table row
  - Added "Style" section in the preview panel with Tag icon
  - Added "About" section in the preview panel with styled summary box
- **Type Safety**: Updated TypeScript interfaces to include the new `editorialSummary` field across components

## Implementation Details
- Organization type classification only displays when the type is not "UNKNOWN"
- Text truncation applied to both style labels (max 180px) and summaries (max 220px) to maintain table layout
- Editorial summaries are displayed in italic with muted styling to distinguish them from primary information
- The preview panel uses a bordered box with muted background for the summary section for better visual hierarchy

https://claude.ai/code/session_01XBMnfGNTLuPQycQ33QMtmB