### PR TITLE
fix: stop sending duplicate form notifications via Cloudflare worker

### DIFF
--- a/src/app/api/booking-request/route.ts
+++ b/src/app/api/booking-request/route.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import { prisma } from "@/lib/db";
 import { handleApiError, ApiError } from "@/lib/api-error";
 import { sendBookingNotification } from "@/lib/notifications/booking-notification";
-import { sendCloudflareNotification } from "@/lib/notifications/cloudflare-notify";
 
 // Map project type from form to service type
 const projectTypeToServiceType: Record<string, string> = {
@@ -158,9 +157,8 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    // Send notifications — await both so they complete before the response
-    const [resendResult, cfResult] = await Promise.allSettled([
-      sendBookingNotification({
+    try {
+      await sendBookingNotification({
         bookingId: booking.id,
         contactName: booking.contact ? `${booking.contact.firstName} ${booking.contact.lastName}` : 'Unknown Contact',
         contactEmail: booking.contact?.email ?? '',
@@ -171,25 +169,9 @@ export async function POST(request: NextRequest) {
         location: null,
         amount: null,
         clientNotes: booking.clientNotes,
-      }),
-      sendCloudflareNotification({
-        type: 'booking_request',
-        name,
-        email,
-        phone: phone || undefined,
-        organization: organization || undefined,
-        serviceType: projectType,
-        eventDate: eventDate || undefined,
-        budget: budget || undefined,
-        message: message || undefined,
-      }),
-    ]);
-
-    if (resendResult.status === 'rejected') {
-      console.error("[BOOKING-REQUEST] Resend notification threw:", resendResult.reason);
-    }
-    if (cfResult.status === 'rejected') {
-      console.error("[BOOKING-REQUEST] Cloudflare notification threw:", cfResult.reason);
+      });
+    } catch (err) {
+      console.error("[BOOKING-REQUEST] Resend notification threw:", err);
     }
 
     return NextResponse.json({

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import { prisma } from "@/lib/db";
 import { handleApiError, ApiError } from "@/lib/api-error";
 import { sendSignupNotification } from "@/lib/notifications/signup-notification";
-import { sendCloudflareNotification } from "@/lib/notifications/cloudflare-notify";
 
 const ContactFormSchema = z.object({
   firstName: z.string().min(1, "First name is required"),
@@ -52,27 +51,15 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    // Send notifications — await both so they complete before the response
-    const [resendResult, cfResult] = await Promise.allSettled([
-      sendSignupNotification({
+    try {
+      await sendSignupNotification({
         type: 'contact',
         name: `${firstName} ${lastName}`,
         email,
         message: `Subject: ${subject}\n\n${message}`,
-      }),
-      sendCloudflareNotification({
-        type: 'contact',
-        name: `${firstName} ${lastName}`,
-        email,
-        message: `Subject: ${subject}\n\n${message}`,
-      }),
-    ]);
-
-    if (resendResult.status === 'rejected') {
-      console.error("[CONTACT] Resend notification threw:", resendResult.reason);
-    }
-    if (cfResult.status === 'rejected') {
-      console.error("[CONTACT] Cloudflare notification threw:", cfResult.reason);
+      });
+    } catch (err) {
+      console.error("[CONTACT] Resend notification threw:", err);
     }
 
     return NextResponse.json({

--- a/src/lib/notifications/booking-notification.ts
+++ b/src/lib/notifications/booking-notification.ts
@@ -267,6 +267,7 @@ export async function sendBookingNotification(
     const adminResult = await resend.emails.send({
       from: fromEmail,
       to: NOTIFICATION_EMAILS,
+      replyTo: data.contactEmail,
       subject: `🎵 New Booking Request: ${getServiceTypeLabel(data.serviceType)} - ${data.contactName}`,
       html: generateAdminEmailHtml(data),
       tags: [


### PR DESCRIPTION
## Summary

The contact and booking-request routes were firing two parallel notification paths per submission:

1. **Resend** — properly formatted, with `replyTo` set to the form submitter.
2. **Cloudflare Worker** (via `sendCloudflareNotification`) — a second email through Cloudflare Email Routing, sent from `notifications@dekesharon.com` with **no Reply-To** header, so replies bounce to that mailbox instead of the submitter.

Deke reported receiving two emails per submission and asked us to kill the one whose Reply-To wasn't the submitter. The forwarded sample matches the Cloudflare Worker output (subject `New Contact Form: …`, From `notifications@dekesharon.com`), so this PR drops that call.

## Changes

- `src/app/api/contact/route.ts` — drop the `sendCloudflareNotification` call and import; collapse the `Promise.allSettled` into a single awaited Resend send.
- `src/app/api/booking-request/route.ts` — same as above for the booking form.
- `src/lib/notifications/booking-notification.ts` — add `replyTo: data.contactEmail` on the admin email so replies land with the submitter (matches the contact-form behavior in `signup-notification.ts`).

The `cloudflare-notify.ts` helper stays in place; `/api/notifications/debug` still uses it for manual diagnostics.

## Test plan

- [ ] Submit the landing-page contact form with a test address — confirm exactly **one** email arrives, From `RESEND_FROM_EMAIL`, with Reply-To set to the submitter.
- [ ] Submit the landing-page booking-request form — same checks.
- [ ] Verify server logs show `[NOTIFICATION:RESEND:*]` lines and no `[NOTIFICATION:CF]` lines from the form routes.

https://claude.ai/code/session_01K8fYfbFvvcB1qcgcD8KMaA

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8fYfbFvvcB1qcgcD8KMaA)_