### PR TITLE
fix: use dekesharon.com as fallback for admin notification dashboard links

### DIFF
--- a/src/lib/notifications/booking-notification.ts
+++ b/src/lib/notifications/booking-notification.ts
@@ -148,7 +148,7 @@ function generateAdminEmailHtml(data: BookingNotificationData): string {
     ` : ''}
 
     <div style="margin-top: 30px; padding: 20px; background: #1a1a2e; border-radius: 8px; text-align: center;">
-      <a href="${process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'}/dashboard/bookings"
+      <a href="${process.env.NEXT_PUBLIC_BASE_URL || 'https://dekesharon.com'}/dashboard/bookings"
          style="display: inline-block; background: #c9a227; color: #fff; padding: 12px 30px; text-decoration: none; border-radius: 5px; font-weight: bold;">
         View in Dashboard
       </a>

--- a/src/lib/notifications/group-request-notification.ts
+++ b/src/lib/notifications/group-request-notification.ts
@@ -112,7 +112,7 @@ function generateAdminEmailHtml(data: GroupRequestNotificationData): string {
     ` : ''}
 
     <div style="margin-top: 30px; padding: 20px; background: #1a1a2e; border-radius: 8px; text-align: center;">
-      <a href="${process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'}/dashboard/groups"
+      <a href="${process.env.NEXT_PUBLIC_BASE_URL || 'https://dekesharon.com'}/dashboard/groups"
          style="display: inline-block; background: #c9a227; color: #fff; padding: 12px 30px; text-decoration: none; border-radius: 5px; font-weight: bold;">
         View in Dashboard
       </a>

--- a/src/lib/notifications/signup-notification.ts
+++ b/src/lib/notifications/signup-notification.ts
@@ -101,7 +101,7 @@ function generateAdminEmailHtml(data: SignupNotificationData): string {
     ` : ''}
 
     <div style="margin-top: 30px; padding: 20px; background: #1a1a2e; border-radius: 8px; text-align: center;">
-      <a href="${process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'}${config.dashboardPath}"
+      <a href="${process.env.NEXT_PUBLIC_BASE_URL || 'https://dekesharon.com'}${config.dashboardPath}"
          style="display: inline-block; background: #c9a227; color: #fff; padding: 12px 30px; text-decoration: none; border-radius: 5px; font-weight: bold;">
         View in Dashboard
       </a>

--- a/src/lib/notifications/subscriber-notification.ts
+++ b/src/lib/notifications/subscriber-notification.ts
@@ -78,7 +78,7 @@ function generateAdminEmailHtml(data: SubscriberNotificationData): string {
     </table>
 
     <div style="margin-top: 30px; padding: 20px; background: #1a1a2e; border-radius: 8px; text-align: center;">
-      <a href="${process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'}/dashboard"
+      <a href="${process.env.NEXT_PUBLIC_BASE_URL || 'https://dekesharon.com'}/dashboard"
          style="display: inline-block; background: #c9a227; color: #fff; padding: 12px 30px; text-decoration: none; border-radius: 5px; font-weight: bold;">
         View in Dashboard
       </a>


### PR DESCRIPTION
## Summary
- The admin booking notification email's "View in Dashboard" button fell back to `http://localhost:3000/dashboard/bookings` when `NEXT_PUBLIC_BASE_URL` was unset, making the link unusable for Deke when receiving real notifications.
- Updated the fallback to `https://dekesharon.com` so the link always points to the live dashboard.
- Applied the same fix to the three other admin notification emails that had the same bug pattern: group requests, signup, and subscriber notifications.

## Test plan
- [ ] Trigger a booking request and confirm the admin email's "View in Dashboard" link points to `https://dekesharon.com/dashboard/bookings`
- [ ] If `NEXT_PUBLIC_BASE_URL` is set in production, confirm it still takes precedence over the fallback
- [ ] Spot-check the group request, signup, and subscriber notification emails for correct dashboard links

---
_Generated by [Claude Code](https://claude.ai/code/session_01ER3BKpC1iK6qSL7ufvKWf8)_